### PR TITLE
Fix for SQL error in mangos.sql

### DIFF
--- a/sql/mangos.sql
+++ b/sql/mangos.sql
@@ -1396,7 +1396,7 @@ CREATE TABLE `db_script_string` (
   `type` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `language` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `emote` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `comment` text
+  `comment` text,
   PRIMARY KEY  (`entry`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 


### PR DESCRIPTION
mangos.sql contains a small typo that makes the import of the dump fail, this fixes it.
