### PR TITLE
Fixed issue with db_version being set to the wrong value

### DIFF
--- a/sql/updates/12523_01_mangos_db_script_string.sql
+++ b/sql/updates/12523_01_mangos_db_script_string.sql
@@ -1,4 +1,4 @@
-ALTER TABLE db_version CHANGE COLUMN required_12507_01_mangos_spell_proc_event required_12522_01_mangos_db_script_string bit;
+ALTER TABLE db_version CHANGE COLUMN required_12507_01_mangos_spell_proc_event required_12523_01_mangos_db_script_string bit;
 
 ALTER TABLE db_script_string ADD COLUMN sound mediumint(8) unsigned NOT NULL DEFAULT '0' AFTER content_loc8;
 ALTER TABLE db_script_string ADD COLUMN type tinyint(3) unsigned NOT NULL DEFAULT '0' AFTER sound;


### PR DESCRIPTION
A small typo in one of the sql-update files prevented the server from starting, since the version check failed.
