### PR TITLE
Guardian of Blizzard no combat fix

### DIFF
--- a/src/modules/SD2/scripts/world/npcs_special.cpp
+++ b/src/modules/SD2/scripts/world/npcs_special.cpp
@@ -1070,7 +1070,6 @@ struct npc_guardianAI : public ScriptedAI
 
     void Reset() override
     {
-        m_creature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
     }
 
     void UpdateAI(const uint32 /*diff*/) override


### PR DESCRIPTION
Creature was set to not attackable.

Faction ID changed to Demon (73)