### PR TITLE
Linux build fix (also tested under VS)

### DIFF
--- a/src/shared/Database/DatabaseEnv.h
+++ b/src/shared/Database/DatabaseEnv.h
@@ -27,7 +27,7 @@
 
 #include "Common/Common.h"
 #include "Log/Log.h"
-#include "Errors.h"
+#include "Utilities/Errors.h"
 
 #include "Database/Field.h"
 #include "Database/QueryResult.h"

--- a/src/shared/Database/QueryResultMysql.cpp
+++ b/src/shared/Database/QueryResultMysql.cpp
@@ -25,7 +25,7 @@
 #ifndef DO_POSTGRESQL
 
 #include "DatabaseEnv.h"
-#include "Errors.h"
+#include "Utilities/Errors.h"
 
 QueryResultMysql::QueryResultMysql(MYSQL_RES* result, MYSQL_FIELD* fields, uint64 rowCount, uint32 fieldCount) :
     QueryResult(rowCount, fieldCount), mResult(result)

--- a/src/shared/Linux/PosixDaemon.h
+++ b/src/shared/Linux/PosixDaemon.h
@@ -22,8 +22,8 @@
  * and lore are copyrighted by Blizzard Entertainment, Inc.
  */
 
-#include "Common.h"
-#include "Log.h"
+#include "Common/Common.h"
+#include "Log/Log.h" 
 
 /**
  * @brief

--- a/src/shared/LockedQueue/LockedQueue.h
+++ b/src/shared/LockedQueue/LockedQueue.h
@@ -29,7 +29,7 @@
 #include <ace/Thread_Mutex.h>
 #include <deque>
 #include <assert.h>
-#include "Errors.h"
+#include "Utilities/Errors.h"
 
 namespace ACE_Based
 {


### PR DESCRIPTION
The build process under Linux failed due to the system not being able to
locate certain included files.

The path was altered and then the build was successfully tested under
both Linux and VS (Windows).