### PR TITLE
[Core] Fix charged items auctioneering.

### DIFF
--- a/src/game/Object/AuctionHouseMgr.cpp
+++ b/src/game/Object/AuctionHouseMgr.cpp
@@ -955,6 +955,7 @@ bool AuctionEntry::BuildAuctionInfo(WorldPacket& data) const
         sLog.outError("auction to item, that doesn't exist !!!!");
         return false;
     }
+    sLog.outError("AH: item %d preparing", pItem->GetEntry());
     data << uint32(Id);
     data << uint32(pItem->GetEntry());
 
@@ -968,7 +969,7 @@ bool AuctionEntry::BuildAuctionInfo(WorldPacket& data) const
     data << uint32(pItem->GetItemRandomPropertyId());       // random item property id
     data << uint32(pItem->GetItemSuffixFactor());           // SuffixFactor
     data << uint32(pItem->GetCount());                      // item->count
-    data << uint32(pItem->GetSpellCharges());               // item->charge FFFFFFF
+    data << uint32(pItem->GetSpellCharges(0,false));        // 0xFFFFFFFF - item->charge + 1
     data << uint32(0);                                      // item flags (dynamic?) (0x04 no lockId?)
     data << ObjectGuid(HIGHGUID_PLAYER, owner);             // Auction->owner
     data << uint32(startbid);                               // Auction->startbid (not sure if useful)

--- a/src/game/Object/AuctionHouseMgr.cpp
+++ b/src/game/Object/AuctionHouseMgr.cpp
@@ -955,7 +955,6 @@ bool AuctionEntry::BuildAuctionInfo(WorldPacket& data) const
         sLog.outError("auction to item, that doesn't exist !!!!");
         return false;
     }
-    sLog.outError("AH: item %d preparing", pItem->GetEntry());
     data << uint32(Id);
     data << uint32(pItem->GetEntry());
 
@@ -969,7 +968,7 @@ bool AuctionEntry::BuildAuctionInfo(WorldPacket& data) const
     data << uint32(pItem->GetItemRandomPropertyId());       // random item property id
     data << uint32(pItem->GetItemSuffixFactor());           // SuffixFactor
     data << uint32(pItem->GetCount());                      // item->count
-    data << uint32(pItem->GetSpellCharges(0,false));        // 0xFFFFFFFF - item->charge + 1
+    data << uint32(pItem->GetSpellCharges(0, false));       // 0xFFFFFFFF - item->charge + 1
     data << uint32(0);                                      // item flags (dynamic?) (0x04 no lockId?)
     data << ObjectGuid(HIGHGUID_PLAYER, owner);             // Auction->owner
     data << uint32(startbid);                               // Auction->startbid (not sure if useful)

--- a/src/game/Object/Item.cpp
+++ b/src/game/Object/Item.cpp
@@ -1301,3 +1301,19 @@ uint32 Item::GetScriptId() const
 {
     return sScriptMgr.GetBoundScriptId(SCRIPTED_ITEM, GetEntry());
 }
+
+int32 Item::GetSpellCharges(uint8 index, bool normal) const
+{
+    int32 val = GetInt32Value(ITEM_FIELD_SPELL_CHARGES + index);
+    if (normal)
+    {
+        val = (val < -1) ? -val : val;
+    }
+    return val;
+}
+
+void Item::SetSpellCharges(uint8 index, int32 value)
+{
+    SetInt32Value(ITEM_FIELD_SPELL_CHARGES + index, (value > 0) ? -value : value);
+}
+ 

--- a/src/game/Object/Item.h
+++ b/src/game/Object/Item.h
@@ -362,8 +362,8 @@ class Item : public Object
         void UpdateDuration(Player* owner, uint32 diff);
 
         // spell charges (signed but stored as unsigned)
-        int32 GetSpellCharges(uint8 index/*0..5*/ = 0) const { return GetInt32Value(ITEM_FIELD_SPELL_CHARGES + index); }
-        void SetSpellCharges(uint8 index/*0..5*/, int32 value) { SetInt32Value(ITEM_FIELD_SPELL_CHARGES + index, value); }
+        int32 GetSpellCharges(uint8 index = 0, bool normal = true) const;
+        void SetSpellCharges(uint8 index, int32 value);
         bool HasMaxCharges() const;
         void RestoreCharges();
 


### PR DESCRIPTION
    - When creating items with charges (ie Amulet of the Moon), the server wrongly inform the client about the charges they have.
    - This fixes issue [203](https://www.getmangos.eu/issue.php?issueid=203)