### PR TITLE
Fix Blood Draining enchant aura

### DIFF
--- a/src/game/WorldHandlers/UnitAuraProcHandler.cpp
+++ b/src/game/WorldHandlers/UnitAuraProcHandler.cpp
@@ -3000,8 +3000,8 @@ SpellAuraProcResult Unit::HandleProcTriggerSpellAuraProc(Unit* pVictim, uint32 d
                 {
                     // When your health drops below 35% ....
                     int32 health35 = int32(GetMaxHealth() * 35 / 100);
-                    if (int32(GetHealth()) - int32(damage) >= health35 || int32(GetHealth()) < health35)
-                        return SPELL_AURA_PROC_FAILED;
+                    if (GetHealth() - damage > health35)
+						return SPELL_AURA_PROC_FAILED;
 
                     trigger_spell_id = 64569;
 


### PR DESCRIPTION
The Aura for the enchant Blood Draining, did not heal when active. This fix
corrected that problem.
Issue and fix found here in the tracker.
https://www.getmangos.eu/bug-tracker/mangos-two/Blood-Draining-not-work-on-hea-r17/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/139)
<!-- Reviewable:end -->
