### PR TITLE
Use pet level modifiers for SPELL_EFFECT_SUMMON_PET (56)

### DIFF
--- a/src/game/WorldHandlers/SpellEffects.cpp
+++ b/src/game/WorldHandlers/SpellEffects.cpp
@@ -6687,7 +6687,7 @@ void Spell::EffectSummonPet(SpellEffectIndex eff_idx)
 
     NewSummon->SetRespawnCoord(pos);
 
-    uint32 petlevel = m_caster->getLevel();
+	uint32 petlevel = std::max(m_caster->getLevel() + m_spellInfo->EffectMultipleValue[eff_idx], 1.0f);
     NewSummon->setPetType(SUMMON_PET);
 
     uint32 faction = m_caster->getFaction();


### PR DESCRIPTION
Cmangos Correction.

[12896] Use pet level modifiers for SPELL_EFFECT_SUMMON_PET (56)
Close #155
Signed-off-by: Xfurry <xfurry@scriptdev2.com>
https://github.com/cmangos/mangos-wotlk/commit/622dc60

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/140)
<!-- Reviewable:end -->
