### PR TITLE
Fix ACHIEVEMENT_CRITERIA_TYPE_OWN_ITEM

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -11030,7 +11030,8 @@ Item* Player::StoreNewItem(ItemPosCountVec const& dest, uint32 item, bool update
     {
         ItemAddedQuestCheck(item, count);
         GetAchievementMgr().UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_RECEIVE_EPIC_ITEM, item, count);
-        pItem = StoreItem(dest, pItem, update);
+		GetAchievementMgr().UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_OWN_ITEM, item, count);
+		pItem = StoreItem(dest, pItem, update);
     }
     return pItem;
 }
@@ -11059,7 +11060,6 @@ Item* Player::StoreItem(ItemPosCountVec const& dest, Item* pItem, bool update)
         lastItem = _StoreItem(pos, pItem, count, true, update);
     }
 
-    GetAchievementMgr().UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_OWN_ITEM, entry);
     return lastItem;
 }
 

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -8364,6 +8364,12 @@ bool Unit::IsVisibleForOrDetect(Unit const* u, WorldObject const* viewPoint, boo
         if (u->GetTypeId() != TYPEID_PLAYER || !((Player*)u)->isGameMaster())
             { return false; }
 
+	    // Death Knights in starting zones with Undying Resolve buff or
+		    // in Acherus with Dominion Over Acherus buff - won't see opposite faction
+		if (u->GetTypeId() == TYPEID_PLAYER && GetTypeId() == TYPEID_PLAYER && !((Player*)u)->isGameMaster() &&
+		  ((Player*)u)->GetTeam() != ((Player*)this)->GetTeam() && (u->HasAura(51915) || u->HasAura(51721)))
+		 return false;
+	
     // Visible units, always are visible for all units, except for units under invisibility and phases
     if (m_Visibility == VISIBILITY_ON && u->m_invisibilityMask == 0)
         { return true; }

--- a/src/game/WorldHandlers/AchievementMgr.cpp
+++ b/src/game/WorldHandlers/AchievementMgr.cpp
@@ -1291,12 +1291,18 @@ void AchievementMgr::UpdateAchievementCriteria(AchievementCriteriaTypes type, ui
                 break;
             }
             case ACHIEVEMENT_CRITERIA_TYPE_OWN_ITEM:
-                // speedup for non-login case
-                if (miscvalue1 && achievementCriteria->own_item.itemID != miscvalue1)
-                    continue;
-                change = GetPlayer()->GetItemCount(achievementCriteria->own_item.itemID, true);
-                progressType = PROGRESS_HIGHEST;
-                break;
+			{
+				// speedup for non-login case
+				if (miscvalue1 && achievementCriteria->own_item.itemID != miscvalue1)
+					continue;
+				// check item count
+				if(!miscvalue2)
+					continue;
+
+				change = miscvalue2;
+				progressType = PROGRESS_ACCUMULATE;
+				break;
+			}
             case ACHIEVEMENT_CRITERIA_TYPE_WIN_RATED_ARENA:
                 // miscvalue1 contains the personal rating
                 if (!miscvalue1)                            // no update at login

--- a/src/game/WorldHandlers/SpellAuras.cpp
+++ b/src/game/WorldHandlers/SpellAuras.cpp
@@ -9164,6 +9164,10 @@ void SpellAuraHolder::_AddSpellAuraHolder()
     // Faerie Fire (druid versions)
     if (m_spellProto->IsFitToFamily(SPELLFAMILY_DRUID, UI64LIT(0x0000000000000400)))
         m_target->ModifyAuraState(AURA_STATE_FAERIE_FIRE, true);
+	
+      // Sting (hunter's pet ability)
+		 if (m_spellProto->Category == 1133)
+		 m_target->ModifyAuraState(AURA_STATE_FAERIE_FIRE, true);
 
         // Victorious
         if (m_spellProto->IsFitToFamily(SPELLFAMILY_WARRIOR, UI64LIT(0x0004000000000000)))


### PR DESCRIPTION
Instead of calculation the total number of items in player's
inventory/bank/equipment
use counter for count every new stored item.
- Credit found here >> https://github.com/mangosR2/mangos/commit/2fca92e

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/142)
<!-- Reviewable:end -->
