### PR TITLE
Game object summon spells

### DIFF
--- a/src/game/WorldHandlers/SpellEffects.cpp
+++ b/src/game/WorldHandlers/SpellEffects.cpp
@@ -5547,12 +5547,14 @@ bool Spell::DoSummonWild(CreatureSummonPositions& list, SummonPropertiesEntry co
             // summon->SetCreatorGuid(m_caster->GetObjectGuid());
 
             // Notify original caster if not done already
-            if (m_originalCaster && m_originalCaster != m_caster && m_originalCaster->GetTypeId() == TYPEID_UNIT && ((Creature*)m_originalCaster)->AI())
-                ((Creature*)m_originalCaster)->AI()->JustSummoned(summon);
+			if (m_originalCaster && m_originalCaster != m_caster && m_originalCaster->GetTypeId() == TYPEID_UNIT && ((Creature*)m_originalCaster)->AI())
+			{
+				((Creature*)m_originalCaster)->AI()->JustSummoned(summon);
 #ifdef ENABLE_ELUNA
-            if (Unit* summoner = m_originalCaster->ToUnit())
-                sEluna->OnSummoned(summon, summoner);
+				if (Unit* summoner = m_originalCaster->ToUnit())
+					sEluna->OnSummoned(summon, summoner);
 #endif
+			}
         }
         else
             return false;
@@ -5842,15 +5844,17 @@ bool Spell::DoSummonPossessed(CreatureSummonPositions& list, SummonPropertiesEnt
     }
 
     // Notify Summoner
-    if (m_originalCaster && m_originalCaster != m_caster && m_originalCaster->GetTypeId() == TYPEID_UNIT && ((Creature*)m_originalCaster)->AI())
-        ((Creature*)m_originalCaster)->AI()->JustSummoned(spawnCreature);
+	if (m_originalCaster && m_originalCaster != m_caster && m_originalCaster->GetTypeId() == TYPEID_UNIT && ((Creature*)m_originalCaster)->AI())
+	{
+		((Creature*)m_originalCaster)->AI()->JustSummoned(spawnCreature);
 
 #ifdef ENABLE_ELUNA
-    if (Unit* summoner = m_originalCaster->ToUnit())
-        sEluna->OnSummoned(spawnCreature, summoner);
+		if (Unit* summoner = m_originalCaster->ToUnit())
+			sEluna->OnSummoned(spawnCreature, summoner);
 #endif
-
-    return true;
+	}
+		return true;
+	
 }
 
 bool Spell::DoSummonPet(SpellEffectIndex eff_idx)


### PR DESCRIPTION
- spell 21078 will no longer crash the server when called upon.
- The Eye of Archerus crash in the Death knight starting area has been
crushed and will work as intended.
-- A vere special call out to H0zen for his help once again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/144)
<!-- Reviewable:end -->
