### PR TITLE
Add spell school prohibition to interrupts

### DIFF
--- a/src/game/Object/Creature.h
+++ b/src/game/Object/Creature.h
@@ -426,6 +426,7 @@ struct TrainerSpellData
 };
 
 typedef std::map<uint32, time_t> CreatureSpellCooldowns;
+typedef std::map<SpellSchoolMask, time_t> CreatureSchoolProhibition;
 
 // max different by z coordinate for creature aggro reaction
 #define CREATURE_Z_ATTACK_RANGE 3
@@ -588,10 +589,13 @@ class Creature : public Unit
 
         void _AddCreatureSpellCooldown(uint32 spell_id, time_t end_time);
         void _AddCreatureCategoryCooldown(uint32 category, time_t apply_time);
+        void _ProhibitSpellSchool(SpellSchoolMask idSchoolMask, time_t end_time);
         void AddCreatureSpellCooldown(uint32 spellid);
         bool HasSpellCooldown(uint32 spell_id) const;
         bool HasCategoryCooldown(uint32 spell_id) const;
+        bool HasSchoolProhibition(SpellSchoolMask idSchoolMask) const;
         uint32 GetCreatureSpellCooldownDelay(uint32 spellId) const;
+        void ProhibitSpellSchool(SpellSchoolMask idSchoolMask, uint32 unTimeMs) override;
 
         bool HasSpell(uint32 spellID) const override;
 
@@ -704,6 +708,7 @@ class Creature : public Unit
         uint32 m_spells[CREATURE_MAX_SPELLS];
         CreatureSpellCooldowns m_CreatureSpellCooldowns;
         CreatureSpellCooldowns m_CreatureCategoryCooldowns;
+        CreatureSchoolProhibition m_CreatureSchoolProhibition;
 
         float GetAttackDistance(Unit const* pl) const;
 

--- a/src/game/Object/CreatureAI.cpp
+++ b/src/game/Object/CreatureAI.cpp
@@ -47,6 +47,14 @@ CanCastResult CreatureAI::CanCastSpell(Unit* pTarget, const SpellEntry* pSpell, 
     // If not triggered, we check
     if (!isTriggered)
     {
+        // Spell is on cooldown
+        if (m_creature->HasSpellCooldown(pSpell->Id))
+            { return CAST_FAIL_STATE; }
+
+        // School is prohibited
+        if (m_creature->HasSchoolProhibition(SpellSchoolMask(pSpell->SchoolMask)))
+            { return CAST_FAIL_STATE; }
+
         // State does not allow
         if (m_creature->hasUnitState(UNIT_STAT_CAN_NOT_REACT_OR_LOST_CONTROL))
             { return CAST_FAIL_STATE; }
@@ -113,7 +121,7 @@ CanCastResult CreatureAI::DoCastSpellIfCan(Unit* pTarget, uint32 uiSpell, uint32
             }
 
             // Interrupt any previous spell
-            if (uiCastFlags & CAST_INTERRUPT_PREVIOUS && pCaster->IsNonMeleeSpellCasted(false))
+            if ((uiCastFlags & CAST_INTERRUPT_PREVIOUS) && pCaster->IsNonMeleeSpellCasted(false))
                 { pCaster->InterruptNonMeleeSpells(false); }
 
             pCaster->CastSpell(pTarget, pSpell, uiCastFlags & CAST_TRIGGERED, NULL, NULL, uiOriginalCasterGUID);


### PR DESCRIPTION
Add spell school prohibition to interrupts
Creatures now honor spell cooldowns for both behavior and event AI
Fix setting both shadow and arcane resistance from arcane resistance template value

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/148)
<!-- Reviewable:end -->
