### PR TITLE
Fix .gobject add #guid

### DIFF
--- a/src/game/Object/GameObject.cpp
+++ b/src/game/Object/GameObject.cpp
@@ -172,8 +172,8 @@ bool GameObject::Create(uint32 guidlow, uint32 name_id, Map* map, uint32 phaseMa
     // let's make sure we don't send the client invalid quaternion
     if (rx == 0.0f && ry == 0.0f && rz == 0.0f)
     {
-        ry = sin(ang/2);
-        rz = cos(ang/2);
+        rz = sin(ang/2);
+        rw = cos(ang/2);
     }
 
     G3D::Quat q(rx, ry, rz, rw);


### PR DESCRIPTION
Fixed with code as it is on vanilla and tbc.
 sin must be put in z and cos in w, otherwise object rotate on an horiozntal line in the space (not in a vertical by the player xy coords)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/151)
<!-- Reviewable:end -->
