### PR TITLE
Fix stock unit frames displaying group members as offline after teleport

### DIFF
--- a/src/game/WorldHandlers/MovementHandler.cpp
+++ b/src/game/WorldHandlers/MovementHandler.cpp
@@ -204,6 +204,10 @@ void WorldSession::HandleMoveWorldportAckOpcode()
 
     // lets process all delayed operations on successful teleport
     GetPlayer()->ProcessDelayedOperations();
+
+    // notify group after successful teleport
+    if (_player->GetGroup())
+        _player->SetGroupUpdateFlag(GROUP_UPDATE_FULL);
 }
 
 void WorldSession::HandleMoveTeleportAckOpcode(WorldPacket& recv_data)


### PR DESCRIPTION
Source: https://github.com/cmangos/mangos-wotlk/commit/6224b3e

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/154)
<!-- Reviewable:end -->
