### PR TITLE
Fixed a bug where destroying a channeling object would crash the server.

### DIFF
--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -3071,7 +3071,10 @@ void Spell::cancel()
                 {
                     Unit* unit = m_caster->GetObjectGuid() == (*ihit).targetGUID ? m_caster : sObjectAccessor.GetUnit(*m_caster, ihit->targetGUID);
                     if (unit && unit->IsAlive())
-                        { unit->RemoveAurasByCasterSpell(m_spellInfo->Id, m_caster->GetObjectGuid()); }
+                        {
+                            unit->RemoveAurasByCasterSpell(m_spellInfo->Id, m_caster->GetObjectGuid());
+                            return;
+                        }
 
                     // prevent other effects applying if spell is already interrupted
                     // i.e. if effects have different targets and it was interrupted on one of them when


### PR DESCRIPTION
See bug report: https://www.getmangos.eu/bug-tracker/mangos-two/rough-stone-statue-server-crash-r1627/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/165)
<!-- Reviewable:end -->
