### PR TITLE
Fixed(Linux, MMaps extracting): wrong path to MoveMapsGen.sh

### DIFF
--- a/linux/getmangos.sh
+++ b/linux/getmangos.sh
@@ -1421,9 +1421,9 @@ function ExtractResources
 
         Log "Copying MMaps extractor" 0
         rm -f "$GAMEPATH/MoveMapGen.sh"
-        cp "$INSTPATH/bin/tools/MoveMapGen.sh" "$GAMEPATH"
-        cp "$INSTPATH/bin/tools/offmesh.txt" "$GAMEPATH"
-        cp "$INSTPATH/bin/tools/mmap_excluded.txt" "$GAMEPATH"
+        cp "$INSTPATH/bin/MoveMapGen.sh" "$GAMEPATH"
+        cp "$INSTPATH/bin/offmesh.txt" "$GAMEPATH"
+        cp "$INSTPATH/bin/mmap_excluded.txt" "$GAMEPATH"
         cp "$INSTPATH/bin/tools/mmap-extractor" "$GAMEPATH"
 
         CPU=$($DLGAPP --backtitle "MaNGOS Linux Build Configuration" --title "Please provide the number of CPU to be used to generate MMaps (1-4)" \


### PR DESCRIPTION
Hi!

I got few errors:

``` shell
+ cp /home/mangos/two/bin/tools/MoveMapGen.sh /root/WoW_3.3.5_12340
cp: cannot stat '/home/mangos/two/bin/tools/MoveMapGen.sh': No such file or directory
+ cp /home/mangos/two/bin/tools/offmesh.txt /root/WoW_3.3.5_12340
cp: cannot stat '/home/mangos/two/bin/tools/offmesh.txt': No such file or directory
+ cp /home/mangos/two/bin/tools/mmap_excluded.txt /root/WoW_3.3.5_12340
cp: cannot stat '/home/mangos/two/bin/tools/mmap_excluded.txt': No such file or directory
+ cp /home/mangos/two/bin/tools/mmap-extractor /root/WoW_3.3.5_12340
```

and fixed it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/171)
<!-- Reviewable:end -->
