### PR TITLE
Fixed a bug where the worldport command handler would not port to val…

### DIFF
--- a/src/game/Server/Opcodes.cpp
+++ b/src/game/Server/Opcodes.cpp
@@ -40,7 +40,7 @@ OpcodeHandler opcodeTable[NUM_MSG_TYPES] =
     /*0x005*/ { "SMSG_QUERY_OBJECT_POSITION",                   STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               },
     /*0x006*/ { "CMSG_QUERY_OBJECT_ROTATION",                   STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     },
     /*0x007*/ { "SMSG_QUERY_OBJECT_ROTATION",                   STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               },
-    /*0x008*/ { "CMSG_WORLD_TELEPORT",                          STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleWorldTeleportOpcode       },
+    /*0x008*/ { "CMSG_WORLD_TELEPORT",                          STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::WorldTeleportHandler            },
     /*0x009*/ { "CMSG_TELEPORT_TO_UNIT",                        STATUS_LOGGEDIN, PROCESS_INPLACE,      &WorldSession::Handle_NULL                     },
     /*0x00A*/ { "CMSG_ZONE_MAP",                                STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     },
     /*0x00B*/ { "SMSG_ZONE_MAP",                                STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               },

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -825,7 +825,7 @@ class WorldSession
         void HandleReportPvPAFK(WorldPacket& recv_data);
 
         void HandleWardenDataOpcode(WorldPacket& recv_data);
-        void HandleWorldTeleportOpcode(WorldPacket& recv_data);
+        void WorldTeleportHandler(WorldPacket& recv_data);
         void HandleMinimapPingOpcode(WorldPacket& recv_data);
         void HandleRandomRollOpcode(WorldPacket& recv_data);
         void HandleFarSightOpcode(WorldPacket& recv_data);

--- a/src/game/WorldHandlers/MiscHandler.cpp
+++ b/src/game/WorldHandlers/MiscHandler.cpp
@@ -1273,46 +1273,31 @@ void WorldSession::HandleInspectHonorStatsOpcode(WorldPacket& recv_data)
     SendPacket(&data);
 }
 
-void WorldSession::HandleWorldTeleportOpcode(WorldPacket& recv_data)
+void WorldSession::WorldTeleportHandler(WorldPacket& recv_data)
 {
-    DEBUG_LOG("WORLD: Received opcode CMSG_WORLD_TELEPORT from %s", GetPlayer()->GetGuidStr().c_str());
+    DEBUG_LOG("WORLD: Received opcode CMSG_WORLD_TELEPORT from %s:", GetPlayer()->GetGuidStr().c_str());
 
-    // write in client console: worldport 469 452 6454 2536 180 or /console worldport 469 452 6454 2536 180
-    // Received opcode CMSG_WORLD_TELEPORT
-    // Time is ***, map=469, x=452.000000, y=6454.000000, z=2536.000000, orient=3.141593
-
-    uint32 time;
-    uint32 mapid;
-    float PositionX;
-    float PositionY;
-    float PositionZ;
-    float Orientation;
-
-    recv_data >> time;                                      // time in m.sec.
-    recv_data >> mapid;
-    recv_data >> PositionX;
-    recv_data >> PositionY;
-    recv_data >> PositionZ;
-    recv_data >> Orientation;                               // o (3.141593 = 180 degrees)
-
-    // DEBUG_LOG("Received opcode CMSG_WORLD_TELEPORT");
-
-    if (GetPlayer()->IsTaxiFlying())
+    if (GetSecurity() != SEC_PLAYER)
     {
-        DEBUG_LOG("Player '%s' (GUID: %u) in flight, ignore worldport command.", GetPlayer()->GetName(), GetPlayer()->GetGUIDLow());
-        return;
-    }
+        uint32 timeMs = time(NULL); // Client-side command timestamp: Used for performance tracking?
+        uint32 worldID = NULL;
+        uint64 mapDBPtr = NULL; // Pointer to the WorldSafeLoc entry, if it exists.
+        Position position = Position();
 
-    DEBUG_LOG("Time %u sec, map=%u, x=%f, y=%f, z=%f, orient=%f", time / 1000, mapid, PositionX, PositionY, PositionZ, Orientation);
+        recv_data >> timeMs;
+        recv_data >> worldID;
+        recv_data >> mapDBPtr;
+        recv_data >> position.x;
+        recv_data >> position.y;
+        recv_data >> position.z;
+        recv_data >> position.o;
 
-    if (GetSecurity() >= SEC_ADMINISTRATOR)
-    {
-        GetPlayer()->TeleportTo(mapid, PositionX, PositionY, PositionZ, Orientation);
+        DEBUG_LOG("Time %u sec, worldID=%u, x=%f, y=%f, z=%f, orient=%f", timeMs, worldID, position.x, position.y, position.z, position.o);
+
+        GetPlayer()->TeleportTo(worldID, position.x, position.y, position.z, position.o, TELE_TO_GM_MODE, NULL);
     }
     else
-    {
         SendNotification(LANG_YOU_NOT_HAVE_PERMISSION);
-    }
 }
 
 void WorldSession::HandleWhoisOpcode(WorldPacket& recv_data)

--- a/src/game/WorldHandlers/MiscHandler.cpp
+++ b/src/game/WorldHandlers/MiscHandler.cpp
@@ -1280,7 +1280,7 @@ void WorldSession::HandleInspectHonorStatsOpcode(WorldPacket& recv_data)
 /****************************************/
 void WorldSession::WorldTeleportHandler(WorldPacket& recv_data)
 {
-    char* commandName = (recv_data.GetOpcode() == CMSG_WORLD_TELEPORT) ? "worldport" : "movecharacter";
+    const char *commandName = (recv_data.GetOpcode() == CMSG_WORLD_TELEPORT) ? "worldport" : "movecharacter";
     DEBUG_LOG("WORLD: Received %s command from account %d:", commandName, GetAccountId());
 
     /* Check that we have permission to perform the function */


### PR DESCRIPTION
…id world coordinates

See the following video for usage examples: https://www.youtube.com/watch?v=-NbKxfxS_tE
I am using my GM client here but the command exists in retail builds as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/174)
<!-- Reviewable:end -->
