### PR TITLE
Implemented the 'level' cheat command handler

### DIFF
--- a/src/game/ChatCommands/PlayerCommands.cpp
+++ b/src/game/ChatCommands/PlayerCommands.cpp
@@ -619,7 +619,7 @@ void ChatHandler::HandleCharacterLevel(Player* player, ObjectGuid player_guid, u
 {
     if (player)
     {
-        player->GiveLevel(newlevel);
+        player->SetLevel(newlevel);
         player->InitTalentForLevel();
         player->SetUInt32Value(PLAYER_XP, 0);
 

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -2876,7 +2876,7 @@ void Player::GiveXP(uint32 xp, Unit* victim)
 
         if (level < sWorld.getConfig(CONFIG_UINT32_MAX_PLAYER_LEVEL))
         {
-            GiveLevel(level + 1);
+            SetLevel(level + 1);
         }
 
         level = getLevel();
@@ -2886,15 +2886,21 @@ void Player::GiveXP(uint32 xp, Unit* victim)
     SetUInt32Value(PLAYER_XP, newXP);
 }
 
-// Update player to next level
-// Current player experience not update (must be update by caller)
-void Player::GiveLevel(uint32 level)
+/****************************************/
+/* Sets the player level if greater than 0 */
+/* and lesser than or equal to DEFAULT_MAX_LEVEL */
+/****************************************/
+void Player::SetLevel(uint32 level)
 {
-    uint8 oldLevel = getLevel();
+	uint8 oldLevel = getLevel();
+	if (level == oldLevel || level > DEFAULT_MAX_LEVEL)
+		return;
 
-    if (level == getLevel())
+	SetUInt32Value(UNIT_FIELD_LEVEL, level);
+    SetUInt32Value(PLAYER_XP, 0);
+    if (GetGroup())
     {
-        return;
+        SetGroupUpdateFlag(GROUP_UPDATE_FLAG_LEVEL);
     }
 
     PlayerLevelInfo info;
@@ -2929,9 +2935,6 @@ void Player::GiveLevel(uint32 level)
     m_Played_time[PLAYED_TIME_LEVEL] = 0;                   // Level Played Time reset
 
     _ApplyAllLevelScaleItemMods(false);
-
-    SetLevel(level);
-
     UpdateSkillsForLevel();
 
     // save base values (bonuses already included in stored stats

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -2994,6 +2994,15 @@ void Player::SetFreeTalentPoints(uint32 points)
     SetUInt32Value(PLAYER_CHARACTER_POINTS1, points);
 }
 
+/****************************************/
+/* DO NOT REMOVE: */
+/* Used for Eluna compatibility */
+/****************************************/
+void Player::GiveLevel(uint32 level)
+{
+    return SetLevel(level);
+}
+
 void Player::UpdateFreeTalentPoints(bool resetIfNeed)
 {
     uint32 level = getLevel();

--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -1191,7 +1191,7 @@ class Player : public Unit
 
 
         void GiveXP(uint32 xp, Unit* victim);
-        void GiveLevel(uint32 level);
+        void SetLevel(uint32 level);
 
         void InitStatsForLevel(bool reapplyMods = false);
 

--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -1191,6 +1191,7 @@ class Player : public Unit
 
 
         void GiveXP(uint32 xp, Unit* victim);
+        void GiveLevel(uint32 level);   /* DO NOT REMOVE: Used for Eluna compatibility */
         void SetLevel(uint32 level);
 
         void InitStatsForLevel(bool reapplyMods = false);

--- a/src/game/Server/Opcodes.cpp
+++ b/src/game/Server/Opcodes.cpp
@@ -69,7 +69,7 @@ OpcodeHandler opcodeTable[NUM_MSG_TYPES] =
     /*0x022*/ { "CMSG_GODMODE",                                 STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     },
     /*0x023*/ { "SMSG_GODMODE",                                 STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               },
     /*0x024*/ { "CMSG_CHEAT_SETMONEY",                          STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     },
-    /*0x025*/ { "CMSG_LEVEL_CHEAT",                             STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     },
+    /*0x025*/ { "CMSG_LEVEL_CHEAT",                             STATUS_LOGGEDIN, PROCESS_INPLACE,      &WorldSession::LevelCheatHandler               },
     /*0x026*/ { "CMSG_PET_LEVEL_CHEAT",                         STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     },
     /*0x027*/ { "CMSG_SET_WORLDSTATE",                          STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     },
     /*0x028*/ { "CMSG_COOLDOWN_CHEAT",                          STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     },

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -830,6 +830,7 @@ class WorldSession
         void HandleWardenDataOpcode(WorldPacket& recv_data);
         void WorldTeleportHandler(WorldPacket& recv_data);
         void GmResurrectHandler(WorldPacket &msg);
+        void LevelCheatHandler(WorldPacket& msg);
         void HandleMinimapPingOpcode(WorldPacket& recv_data);
         void HandleRandomRollOpcode(WorldPacket& recv_data);
         void HandleFarSightOpcode(WorldPacket& recv_data);

--- a/src/game/WorldHandlers/MiscHandler.cpp
+++ b/src/game/WorldHandlers/MiscHandler.cpp
@@ -1311,7 +1311,7 @@ void WorldSession::WorldTeleportHandler(WorldPacket& recv_data)
 
 /****************************************/
 /* This function handles the 'resurrect' client command. */
-/* Usage: resurrect <player name>
+/* Usage: resurrect <player name> */
 /****************************************/
 void WorldSession::GmResurrectHandler(WorldPacket &msg)
 {

--- a/src/game/WorldHandlers/MiscHandler.cpp
+++ b/src/game/WorldHandlers/MiscHandler.cpp
@@ -1360,6 +1360,36 @@ void WorldSession::GmResurrectHandler(WorldPacket &msg)
     }
 }
 
+/****************************************/
+/* This function handles the 'level' client command. */
+/****************************************/
+void WorldSession::LevelCheatHandler(WorldPacket& msg)
+{
+    DEBUG_LOG("WORLD: Received %s message from account %d:", msg.GetOpcodeName(), GetAccountId());
+
+    /* Check that we have permission to perform the function */
+    if (GetSecurity() > SEC_PLAYER)
+    {
+        uint32 curLevel = GetPlayer()->getLevel();
+        uint32 newLevel = 0;
+
+        msg >> newLevel;
+
+        /* Check that the level value is greater than 0 and smaller than the server's max player level for its expansion level */
+        /* and that we have a different level than the one requested... */
+        if ((newLevel != 0 && newLevel <= DEFAULT_MAX_LEVEL) && newLevel != curLevel)
+        {
+            DEBUG_LOG("Leveling player %s from level %d to %d", GetPlayerName(), curLevel, newLevel);
+            GetPlayer()->SetLevel(newLevel);
+        }
+    }
+    else
+    {
+        DEBUG_LOG("Permission denied.");
+        SendNotification(LANG_YOU_NOT_HAVE_PERMISSION);
+    }
+}
+
 void WorldSession::HandleWhoisOpcode(WorldPacket& recv_data)
 {
     DEBUG_LOG("WORLD: Received opcode CMSG_WHOIS");


### PR DESCRIPTION
This command takes for input a player level and can only be executed on the callee. This prevents accidentally setting the level of an unintended player, as is currently possible with the existing command system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/176)
<!-- Reviewable:end -->
