### PR TITLE
Implemented the Logout message handler and refactored the WorldSession logout method

### DIFF
--- a/src/game/Object/ObjectAccessor.cpp
+++ b/src/game/Object/ObjectAccessor.cpp
@@ -86,11 +86,11 @@ void ObjectAccessor::SaveAllPlayers()
 
 void ObjectAccessor::KickPlayer(ObjectGuid guid)
 {
-    if (Player* p = FindPlayer(guid, false))
+    if (Player *pPlayer = FindPlayer(guid, false))
     {
-        WorldSession* s = p->GetSession();
-        s->KickPlayer();                            // mark session to remove at next session list update
-        s->LogoutPlayer(false);                     // logout player without waiting next session list update
+        WorldSession *pSession = pPlayer->GetSession();
+        pSession->KickPlayer();
+        pSession->CharacterLogout();
     }
 }
 

--- a/src/game/Server/Opcodes.cpp
+++ b/src/game/Server/Opcodes.cpp
@@ -106,7 +106,7 @@ OpcodeHandler opcodeTable[NUM_MSG_TYPES] =
     /*0x047*/ { "SMSG_GAMESPEED_SET",                           STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               },
     /*0x048*/ { "CMSG_SERVERTIME",                              STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     },
     /*0x049*/ { "SMSG_SERVERTIME",                              STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               },
-    /*0x04A*/ { "CMSG_PLAYER_LOGOUT",                           STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandlePlayerLogoutOpcode        },
+    /*0x04A*/ { "CMSG_PLAYER_LOGOUT",                           STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandlePlayerLogout        },
     /*0x04B*/ { "CMSG_LOGOUT_REQUEST",                          STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleLogoutRequestOpcode       },
     /*0x04C*/ { "SMSG_LOGOUT_RESPONSE",                         STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               },
     /*0x04D*/ { "SMSG_LOGOUT_COMPLETE",                         STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               },

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -306,7 +306,11 @@ class WorldSession
             return (_logoutTime > 0 && currTime >= _logoutTime + 20);
         }
 
+        // This method is kept for compatibility with Eluna;
+        // The player is always saved before logging out!
         void LogoutPlayer(bool Save);
+
+        void CharacterLogout();
         void KickPlayer();
 
         void QueuePacket(WorldPacket* new_packet);

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -509,7 +509,7 @@ class WorldSession
         void HandleLootMasterGiveOpcode(WorldPacket& recvPacket);
         void HandleWhoOpcode(WorldPacket& recvPacket);
         void HandleLogoutRequestOpcode(WorldPacket& recvPacket);
-        void HandlePlayerLogoutOpcode(WorldPacket& recvPacket);
+        void HandlePlayerLogout(WorldPacket &msg);
         void HandleLogoutCancelOpcode(WorldPacket& recvPacket);
 
         void HandleGMTicketGetTicketOpcode(WorldPacket& recvPacket);

--- a/src/game/WorldHandlers/MiscHandler.cpp
+++ b/src/game/WorldHandlers/MiscHandler.cpp
@@ -371,9 +371,17 @@ void WorldSession::HandleLogoutRequestOpcode(WorldPacket& /*recv_data*/)
     LogoutRequest(time(NULL));
 }
 
-void WorldSession::HandlePlayerLogoutOpcode(WorldPacket& /*recv_data*/)
+void WorldSession::HandlePlayerLogout(WorldPacket &msg)
 {
     DEBUG_LOG("WORLD: Received opcode CMSG_PLAYER_LOGOUT Message");
+    if (GetSecurity() > SEC_PLAYER)
+    {
+        LogoutPlayer(true);
+    }
+    else
+    {
+        SendNotification(LANG_YOU_NOT_HAVE_PERMISSION);
+    }
 }
 
 void WorldSession::HandleLogoutCancelOpcode(WorldPacket& /*recv_data*/)

--- a/src/game/WorldHandlers/MiscHandler.cpp
+++ b/src/game/WorldHandlers/MiscHandler.cpp
@@ -347,7 +347,7 @@ void WorldSession::HandleLogoutRequestOpcode(WorldPacket& /*recv_data*/)
     if (GetPlayer()->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_RESTING) || GetPlayer()->IsTaxiFlying() ||
         GetSecurity() >= (AccountTypes)sWorld.getConfig(CONFIG_UINT32_INSTANT_LOGOUT))
     {
-        LogoutPlayer(true);
+        CharacterLogout();
         return;
     }
 
@@ -376,7 +376,7 @@ void WorldSession::HandlePlayerLogout(WorldPacket &msg)
     DEBUG_LOG("WORLD: Received opcode CMSG_PLAYER_LOGOUT Message");
     if (GetSecurity() > SEC_PLAYER)
     {
-        LogoutPlayer(true);
+        CharacterLogout();
     }
     else
     {


### PR DESCRIPTION
This PR implements the logout message handler and refactors the WorldSession logout by deprecating the WorldSession::LogoutPlayer(bool save) method in favor of WorldSession::CharacterLogout(), which saves the player by default.

The deprecated method is kept for compatibility with Eluna for the time being.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/186)
<!-- Reviewable:end -->
