### PR TITLE
Fix missing bzip2 dependency for CentOS

### DIFF
--- a/linux/getmangos.sh
+++ b/linux/getmangos.sh
@@ -308,7 +308,7 @@ function GetPrerequisites()
           rpm -Uv ftp://rpmfind.net/linux/centos/7/os/x86_64/Packages/libtool-2.4.2-22.el7_3.x86_64.rpm
           rpm -Uv ftp://ftp.pbone.net/mirror/ftp5.gwdg.de/pub/opensuse/repositories/devel:/libraries:/ACE:/micro/CentOS_7/x86_64/ace-devel-6.3.3-55.1.x86_64.rpm
           su -c "yum -y install epel-release"
-          su -c "yum -y install curl autoconf automake cmake3 ace-devel ace-6.3.3 openssl-devel mysql-devel libtool gcc-c++" root
+          su -c "yum -y install curl autoconf automake cmake3 ace-devel ace-6.3.3 openssl-devel mysql-devel libtool gcc-c++ bzip2-devel" root
           ;;
         *)
           OS_VER=0


### PR DESCRIPTION
Currently you will encounter this error
```
CMake Error at /usr/share/cmake3/Modules/FindPackageHandleStandardArgs.cmake:164 (message):
  Could NOT find BZip2 (missing: BZIP2_LIBRARIES BZIP2_INCLUDE_DIR)
```

After yum install the package bzip2-devel, everything is fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/187)
<!-- Reviewable:end -->
