### PR TITLE
Fix Linux build

### DIFF
--- a/src/game/WorldHandlers/ScriptMgr.cpp
+++ b/src/game/WorldHandlers/ScriptMgr.cpp
@@ -29,7 +29,7 @@
 #include "ObjectMgr.h"
 #include "WaypointManager.h"
 #include "World.h"
-#include <DBCStores.cpp>
+#include <DBCStores.h>
 #include "GridNotifiers.h"
 #include "GridNotifiersImpl.h"
 #include "Cell.h"


### PR DESCRIPTION
Fix double inclusion of DBCStores.cpp by changing include in ScriptMgr.cpp from source to header.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/193)
<!-- Reviewable:end -->
