### PR TITLE
Fix player timed events not carrying over between maps

### DIFF
--- a/src/game/Object/Object.cpp
+++ b/src/game/Object/Object.cpp
@@ -1754,19 +1754,13 @@ void WorldObject::SetMap(Map* map)
     m_InstanceId = map->GetInstanceId();
 
 #ifdef ENABLE_ELUNA
-    delete elunaEvents;
-    // On multithread replace this with a pointer to map's Eluna pointer stored in a map
-    elunaEvents = new ElunaEventProcessor(&Eluna::GEluna, this);
+    if (!elunaEvents)
+        elunaEvents = new ElunaEventProcessor(&Eluna::GEluna, this);
 #endif
 }
 
 void WorldObject::ResetMap()
 {
-#ifdef ENABLE_ELUNA
-    delete elunaEvents;
-    elunaEvents = NULL;
-#endif
-
     m_currMap = NULL;
 }
 


### PR DESCRIPTION
Timed events tied to players are removed when a player teleports from one map to another.

In this PR we change it so that timed evens are no longer removed.

See
* https://github.com/ElunaLuaEngine/ElunaTrinityWotlk/commit/a0d10f8ff0e68cf59cd7b2fd62e985adaeb35d9d
* https://discord.com/channels/817077195817353226/1074254244561031248/1074254244561031248

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/194)
<!-- Reviewable:end -->
