### PR TITLE
Adding XP Gains to Battlegrounds (Warsong Gulch)

### DIFF
--- a/src/game/BattleGround/BattleGround.cpp
+++ b/src/game/BattleGround/BattleGround.cpp
@@ -768,6 +768,57 @@ void BattleGround::RewardReputationToTeam(uint32 faction_id, uint32 Reputation, 
 }
 
 /// <summary>
+/// Rewards the XP to team.
+/// </summary>
+/// <param name="event">The battleground event.</param>
+/// <param name="teamId">The team id.</param>
+void BattleGround::RewardXPToTeam(uint8 event, Team teamId)
+{
+    enum BGEvent
+    {
+        WS_FLAG_CAPTURE                   = 1,
+        WS_WIN                            = 2,
+    };
+
+    for (BattleGroundPlayerMap::const_iterator itr = m_Players.begin(); itr != m_Players.end(); ++itr)
+    {
+        if (itr->second.OfflineRemoveTime)
+        {
+            continue;
+        }
+
+        Player* plr = sObjectMgr.GetPlayer(itr->first);
+
+        if (!plr)
+        {
+            sLog.outError("BattleGround:RewardXPToTeam: %s not found!", itr->first.GetString().c_str());
+            continue;
+        }
+
+        Team team = itr->second.PlayerTeam;
+        if (!team)
+        {
+            team = plr->GetTeam();
+        }
+
+        if (team == teamId)
+        {
+            uint32 xp;
+            switch (event)
+            {
+                case WS_FLAG_CAPTURE:
+                    xp = 74 + (4.01 * plr->getLevel()) + (1.19 * pow(plr->getLevel(),2));         // This XP curve is a WIP, was established with a limited dataset pulled from various videos. -fyre
+                    break;
+                case WS_WIN:
+                    xp = (74 + (4.01 * plr->getLevel()) + (1.19 * pow(plr->getLevel(),2)))/2;         // Half of a flag capture. Complete guess. -fyre
+                    break;
+            }
+            plr->GiveXP(xp, nullptr);
+        }
+    }
+}
+
+/// <summary>
 /// Updates the state of the world.
 /// </summary>
 /// <param name="Field">The field.</param>

--- a/src/game/BattleGround/BattleGround.h
+++ b/src/game/BattleGround/BattleGround.h
@@ -873,6 +873,13 @@ class BattleGround
         /**
          * @brief
          *
+         * @param event
+         * @param team
+         */
+        void RewardXPToTeam(uint8 event, Team team);
+        /**
+         * @brief
+         *
          * @param plr
          * @param count
          */

--- a/src/game/BattleGround/BattleGroundWS.cpp
+++ b/src/game/BattleGround/BattleGroundWS.cpp
@@ -608,7 +608,7 @@ void BattleGroundWS::EndBattleGround(Team winner)
     if (winner == ALLIANCE)
     {
         RewardHonorToTeam(GetBonusHonorFromKill(m_HonorWinKills), ALLIANCE);
-                
+
         // Earn XP for any remaining flags not captured by the Horde.
         for (uint8 i = 0; i < (3 - m_TeamScores[TEAM_INDEX_HORDE]); ++i)
         {
@@ -619,7 +619,7 @@ void BattleGroundWS::EndBattleGround(Team winner)
     if (winner == HORDE)
     {
         RewardHonorToTeam(GetBonusHonorFromKill(m_HonorWinKills), HORDE);
-        
+
         // Earn XP for any remaining flags not captured by the Horde.
         for (uint8 i = 0; i < (3 - m_TeamScores[TEAM_INDEX_ALLIANCE]); ++i)
         {

--- a/src/game/BattleGround/BattleGroundWS.cpp
+++ b/src/game/BattleGround/BattleGroundWS.cpp
@@ -226,6 +226,7 @@ void BattleGroundWS::EventPlayerCapturedFlag(Player* source)
         }
         PlaySoundToAll(BG_WS_SOUND_FLAG_CAPTURED_ALLIANCE);
         RewardReputationToTeam(890, m_ReputationCapture, ALLIANCE);
+        RewardXPToTeam(1, ALLIANCE);                        // event = WS_FLAG_CAPTURE
     }
     else
     {
@@ -244,6 +245,7 @@ void BattleGroundWS::EventPlayerCapturedFlag(Player* source)
         }
         PlaySoundToAll(BG_WS_SOUND_FLAG_CAPTURED_HORDE);
         RewardReputationToTeam(889, m_ReputationCapture, HORDE);
+        RewardXPToTeam(1, HORDE);                        // event = WS_FLAG_CAPTURE
     }
     // for flag capture is reward 2 honorable kills
     RewardHonorToTeam(GetBonusHonorFromKill(2), source->GetTeam());
@@ -606,10 +608,25 @@ void BattleGroundWS::EndBattleGround(Team winner)
     if (winner == ALLIANCE)
     {
         RewardHonorToTeam(GetBonusHonorFromKill(m_HonorWinKills), ALLIANCE);
+                
+        // Earn XP for any remaining flags not captured by the Horde.
+        for (uint8 i = 0; i < (3 - m_TeamScores[TEAM_INDEX_HORDE]); ++i)
+        {
+            RewardXPToTeam(1, ALLIANCE);                        // event = WS_FLAG_CAPTURE
+        }
+        RewardXPToTeam(2, ALLIANCE);                        // event = WS_WIN
     }
     if (winner == HORDE)
     {
         RewardHonorToTeam(GetBonusHonorFromKill(m_HonorWinKills), HORDE);
+        
+        // Earn XP for any remaining flags not captured by the Horde.
+        for (uint8 i = 0; i < (3 - m_TeamScores[TEAM_INDEX_ALLIANCE]); ++i)
+        {
+            RewardXPToTeam(1, HORDE);                            // event = WS_FLAG_CAPTURE
+        }
+        RewardXPToTeam(2, HORDE);                            // event = WS_WIN
+
     }
     // complete map_end rewards (even if no team wins)
     RewardHonorToTeam(GetBonusHonorFromKill(m_HonorEndKills), ALLIANCE);


### PR DESCRIPTION
This PR provides the server with the functionality to offer XP as a reward in battlegrounds and provides the framework for other battlegrounds to be included.
This PR focuses on Warsong Gulch only. Three ways to earn XP:
1) Flag Capture (Pictured below as 1, 2, 3)
2) Remaining Flags at the end of the match. (Pictured below as 4, 5, 6 -- in this example, it was a 3-0 win for Horde, so 3 remaining flags.)
3) Win (Pictured below as 7)
![XP Gain Ingame](https://github.com/user-attachments/assets/b9474097-5479-46a1-92dd-42118ad6e9a0)


Values for XP are an approximation and NOT Blizzlike. Using era appropriate videos, we extracted XP gains at different levels. The formula utilized in this PR does not match the values exactly, but does scale very closely.
![XP vs Level](https://github.com/user-attachments/assets/c6421cae-409f-48de-9739-241e5e872c2c)


Thank you to REGNURZA on Discord for identifying the lack of XP provided during battlegrounds and researching videos for XP gains!
Thank you to Neddings on Discord for also researching videos!
Thank you to Xenocide21 on Discord for help with upscaling videos/images!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/197)
<!-- Reviewable:end -->
