### PR TITLE
Fix OpenSSL in windows workflow

### DIFF
--- a/.github/workflows/core_windows_build.yml
+++ b/.github/workflows/core_windows_build.yml
@@ -22,7 +22,7 @@ jobs:
           sdk-version: 22621
 
       - name: Install OpenSSL
-        run: choco install --no-progress openssl --version=3.3.1
+        run: choco install --no-progress openssl
 
       - name: Checkout Submodules
         shell: bash


### PR DESCRIPTION
Ensure choco always installs the latest version of OpenSSL, as previous versions may not always be available for download.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/198)
<!-- Reviewable:end -->
