### PR TITLE
Calendar: fix broken event create/edit/copy (packed-time decode), DST time shift, and silent handler failures

### DIFF
--- a/src/game/WorldHandlers/CalendarHandler.cpp
+++ b/src/game/WorldHandlers/CalendarHandler.cpp
@@ -232,6 +232,10 @@ void WorldSession::HandleCalendarGuildFilter(WorldPacket& recv_data)
     {
         guild->MassInviteToEvent(this, minLevel, maxLevel, minRank);
     }
+    else
+    {
+        sCalendarMgr.SendCalendarCommandResult(_player, CALENDAR_ERROR_GUILD_PLAYER_NOT_IN_GUILD);
+    }
 
     DEBUG_FILTER_LOG(LOG_FILTER_CALENDAR, "Min level [%u], Max level [%u], Min rank [%u]", minLevel, maxLevel, minRank);
 }
@@ -276,6 +280,10 @@ void WorldSession::HandleCalendarArenaTeam(WorldPacket& recv_data)
     {
         team->MassInviteToEvent(this);
     }
+    else
+    {
+        sCalendarMgr.SendCalendarCommandResult(_player, CALENDAR_ERROR_INTERNAL);
+    }
 }
 
 void WorldSession::HandleCalendarAddEvent(WorldPacket& recv_data)
@@ -303,17 +311,12 @@ void WorldSession::HandleCalendarAddEvent(WorldPacket& recv_data)
     recv_data >> unkPackedTime;
     recv_data >> flags;
 
-    // Client sends the event time as a packed bit-field (see timeBitFieldsToSecs), not a UNIX timestamp.
+    // Client sends the event time as a packed bit-field, not UNIX seconds
+    // (see timeBitFieldsToSecs).
     time_t eventTime = timeBitFieldsToSecs(eventPackedTime);
 
-    // prevent events in the past
-    if (eventTime < (GameTime::GetGameTime() - time_t(86400L)))
-    {
-        recv_data.rfinish();
-        return;
-    }
-
-    // 946684800 is 01/01/2000 00:00:00 - default response time
+    // AddEvent() validates date/title/guild/quota and replies with the matching
+    // CALENDAR_ERROR_* on failure, so the handler needs no past-event guard.
     CalendarEvent* cal =  sCalendarMgr.AddEvent(_player->GetObjectGuid(), title, description, type, repeatable, maxInvites, dungeonId, eventTime, timeBitFieldsToSecs(unkPackedTime), flags);
 
     if (cal)
@@ -341,6 +344,11 @@ void WorldSession::HandleCalendarAddEvent(WorldPacket& recv_data)
         }
         sCalendarMgr.SendCalendarEvent(_player, cal, CALENDAR_SENDTYPE_ADD);
     }
+    else
+    {
+        // AddEvent() rejected and already replied; drop the trailing invite list.
+        recv_data.rfinish();
+    }
 }
 
 void WorldSession::HandleCalendarUpdateEvent(WorldPacket& recv_data)
@@ -366,15 +374,9 @@ void WorldSession::HandleCalendarUpdateEvent(WorldPacket& recv_data)
     recv_data >> UnknownPackedTime;
     recv_data >> flags;
 
-    // Client sends the event time as a packed bit-field (see timeBitFieldsToSecs), not a UNIX timestamp.
+    // Client sends the event time as a packed bit-field, not UNIX seconds
+    // (see timeBitFieldsToSecs).
     time_t eventTime = timeBitFieldsToSecs(eventPackedTime);
-
-    // prevent events in the past
-    if (eventTime < (GameTime::GetGameTime() - time_t(86400L)))
-    {
-        recv_data.rfinish();
-        return;
-    }
 
     DEBUG_FILTER_LOG(LOG_FILTER_CALENDAR, "EventId [" UI64FMTD "], InviteId [" UI64FMTD "] Title %s, Description %s, type %u "
                      "Repeatable %u, MaxInvites %u, Dungeon ID %d, Flags %u", eventId, inviteId, title.c_str(),
@@ -397,6 +399,14 @@ void WorldSession::HandleCalendarUpdateEvent(WorldPacket& recv_data)
                 sCalendarMgr.SendCalendarCommandResult(_player, CALENDAR_ERROR_PERMISSIONS);
                 return;
             }
+        }
+
+        // Reject past dates after the existence/permission checks so the client
+        // gets the correct error instead of a silent drop.
+        if (eventTime < (GameTime::GetGameTime() - time_t(86400L)))
+        {
+            sCalendarMgr.SendCalendarCommandResult(_player, CALENDAR_ERROR_INVALID_DATE);
+            return;
         }
 
         oldEventTime = event->EventTime;
@@ -454,14 +464,10 @@ void WorldSession::HandleCalendarCopyEvent(WorldPacket& recv_data)
     DEBUG_FILTER_LOG(LOG_FILTER_CALENDAR, "EventId [" UI64FMTD "] inviteId [" UI64FMTD "]",
                      eventId, inviteId);
 
-    // Client sends the event time as a packed bit-field (see timeBitFieldsToSecs), not a UNIX timestamp.
+    // Client sends the event time as a packed bit-field, not UNIX seconds
+    // (see timeBitFieldsToSecs). CopyEvent() -> AddEvent() validates the date and
+    // replies with the matching CALENDAR_ERROR_* on failure.
     time_t newTime = timeBitFieldsToSecs(packedTime);
-    // prevent events in the past
-    if (newTime < (GameTime::GetGameTime() - time_t(86400L)))
-    {
-        recv_data.rfinish();
-        return;
-    }
 
     sCalendarMgr.CopyEvent(eventId, newTime, guid);
 }

--- a/src/game/WorldHandlers/CalendarHandler.cpp
+++ b/src/game/WorldHandlers/CalendarHandler.cpp
@@ -303,18 +303,18 @@ void WorldSession::HandleCalendarAddEvent(WorldPacket& recv_data)
     recv_data >> unkPackedTime;
     recv_data >> flags;
 
-    //eventPackedTime = uint32(LocalTimeToUTCTime(eventPackedTime));
-    eventPackedTime = GetLocalHourTimestamp(eventPackedTime, 0, true);
+    // Client sends the event time as a packed bit-field (see timeBitFieldsToSecs), not a UNIX timestamp.
+    time_t eventTime = timeBitFieldsToSecs(eventPackedTime);
 
     // prevent events in the past
-    if (time_t(eventPackedTime) < (GameTime::GetGameTime() - time_t(86400L)))
+    if (eventTime < (GameTime::GetGameTime() - time_t(86400L)))
     {
         recv_data.rfinish();
         return;
     }
 
     // 946684800 is 01/01/2000 00:00:00 - default response time
-    CalendarEvent* cal =  sCalendarMgr.AddEvent(_player->GetObjectGuid(), title, description, type, repeatable, maxInvites, dungeonId, timeBitFieldsToSecs(eventPackedTime), timeBitFieldsToSecs(unkPackedTime), flags);
+    CalendarEvent* cal =  sCalendarMgr.AddEvent(_player->GetObjectGuid(), title, description, type, repeatable, maxInvites, dungeonId, eventTime, timeBitFieldsToSecs(unkPackedTime), flags);
 
     if (cal)
     {
@@ -366,11 +366,11 @@ void WorldSession::HandleCalendarUpdateEvent(WorldPacket& recv_data)
     recv_data >> UnknownPackedTime;
     recv_data >> flags;
 
-    //eventPackedTime = uint32(LocalTimeToUTCTime(eventPackedTime));
-    eventPackedTime = GetLocalHourTimestamp(eventPackedTime, 0, true);
+    // Client sends the event time as a packed bit-field (see timeBitFieldsToSecs), not a UNIX timestamp.
+    time_t eventTime = timeBitFieldsToSecs(eventPackedTime);
 
     // prevent events in the past
-    if (time_t(eventPackedTime) < (GameTime::GetGameTime() - time_t(86400L)))
+    if (eventTime < (GameTime::GetGameTime() - time_t(86400L)))
     {
         recv_data.rfinish();
         return;
@@ -403,7 +403,7 @@ void WorldSession::HandleCalendarUpdateEvent(WorldPacket& recv_data)
 
         event->Type = CalendarEventType(type);
         event->Flags = flags;
-        event->EventTime = timeBitFieldsToSecs(eventPackedTime);
+        event->EventTime = eventTime;
         event->UnknownTime = timeBitFieldsToSecs(UnknownPackedTime);
         event->DungeonId = dungeonId;
         event->Title = title;
@@ -454,16 +454,16 @@ void WorldSession::HandleCalendarCopyEvent(WorldPacket& recv_data)
     DEBUG_FILTER_LOG(LOG_FILTER_CALENDAR, "EventId [" UI64FMTD "] inviteId [" UI64FMTD "]",
                      eventId, inviteId);
 
-    //packedTime = uint32(LocalTimeToUTCTime(packedTime));
-    packedTime = GetLocalHourTimestamp(packedTime, 0, true);
+    // Client sends the event time as a packed bit-field (see timeBitFieldsToSecs), not a UNIX timestamp.
+    time_t newTime = timeBitFieldsToSecs(packedTime);
     // prevent events in the past
-    if (time_t(packedTime) < (GameTime::GetGameTime() - time_t(86400L)))
+    if (newTime < (GameTime::GetGameTime() - time_t(86400L)))
     {
         recv_data.rfinish();
         return;
     }
 
-    sCalendarMgr.CopyEvent(eventId, timeBitFieldsToSecs(packedTime), guid);
+    sCalendarMgr.CopyEvent(eventId, newTime, guid);
 }
 
 void WorldSession::HandleCalendarEventInvite(WorldPacket& recv_data)

--- a/src/shared/Utilities/Util.cpp
+++ b/src/shared/Utilities/Util.cpp
@@ -355,6 +355,9 @@ time_t timeBitFieldsToSecs(uint32 packedDate)
     lt.tm_mday = ((packedDate >> 14) & 0x3F) + 1;
     lt.tm_mon = (packedDate >> 20) & 0xF;
     lt.tm_year = ((packedDate >> 24) & 0x1F) + 100;
+    // -1 lets mktime resolve DST for this date; memset had forced 0 (standard
+    // time), which shifted summer dates forward by the DST offset.
+    lt.tm_isdst = -1;
 
     return time_t(mktime(&lt));
 }


### PR DESCRIPTION
## Summary

The in-game Calendar was broken: **creating, editing, and copying events silently did nothing** (no event, no error). This PR fixes the root cause, corrects a DST-related time shift, and makes the handlers reply to the client instead of dropping requests silently.

All changes were verified on a live 3.3.5a client with packet logging (before/after capture), not just static review.

## What was wrong & what changed

### 1. Event create/edit/copy silently failed — `fix(calendar): decode packed event time in add/update/copy`
The 3.3.5a client sends calendar event times as a **packed bit-field** (min/hour/wday/day/month/year), not a UNIX timestamp. `HandleCalendarAddEvent`/`HandleCalendarUpdateEvent`/`HandleCalendarCopyEvent` passed the raw packed value into `GetLocalHourTimestamp()` (which expects seconds) and then re-decoded the result with `timeBitFieldsToSecs()` — a double misuse.

Because a packed bit-field (~4.4e8) is far below current UNIX time (~1.7e9), the "prevent events in the past" guard **always tripped**, so the handler returned with no SMSG reply and the event was never created/edited/copied. (Regression from `96d1400ff5`.)

Fix: decode the packed bit-field to seconds **once** with `timeBitFieldsToSecs()` and use that value for both the guard and the stored time.

### 2. Event times shifted by the DST offset — `fix(calendar): resolve DST when decoding packed event times`
`timeBitFieldsToSecs()` left `tm_isdst = 0`, forcing `mktime` to interpret every date as standard time. On a DST-observing server a summer event entered at 00:00 was stored/echoed as 01:00 (the encode side honours DST). Set `tm_isdst = -1` so `mktime` resolves DST — making decode/encode an exact inverse. Verified: an event created at a fixed hour now echoes back the same hour.

### 3. Silent handler failures → proper client feedback — `fix(calendar): reply to the client on rejected calendar actions`
- **Add/Copy:** removed the redundant handler-side past-event guard and rely on `CalendarMgr::AddEvent` (and `CopyEvent → AddEvent`), which validates date/title/guild/quota and replies with the matching `CALENDAR_ERROR_*`. Added `else { rfinish() }` on the add path to drain the trailing invite list when `AddEvent` returns `NULL`.
- **Update:** moved the past-event check to **after** the event-exists + permission checks and made it send `CALENDAR_ERROR_INVALID_DATE` instead of a silent return, so non-owners / invalid events get the correct error.
- **Guild filter / Arena team:** send a command result when the player has no guild / the arena team isn't found, instead of dropping the request silently.

## Testing (live, packet-level)
- Create / edit / copy / **remove** all succeed, each with the expected SMSG reply (`SMSG_CALENDAR_SEND_EVENT`, `..._EVENT_UPDATED_ALERT`, `..._EVENT_REMOVED_ALERT`), and **no `ByteBufferException`** in the server log.
- DST: `CMSG_CALENDAR_ADD_EVENT`'s `eventPackedTime` now equals the time echoed in `SMSG_CALENDAR_SEND_EVENT` (hour matches exactly).

## Notes
- `CMSG_CALENDAR_REMOVE_EVENT` was also checked against a live capture and is **already correct** (the client sends a 20-byte body with a `u32` trailing flag, matching the server read) — no change needed there.
- Files changed: `src/game/WorldHandlers/CalendarHandler.cpp`, `src/shared/Utilities/Util.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/210)
<!-- Reviewable:end -->
