### PR TITLE
[CRITICAL] Restore the connection lock to a recursive mutex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,10 +62,8 @@ Thumbs.db
 # Build directories
 /bin/
 _build
-build
-/dep/libmpq/autom4te.cache/
-/ACE_wrappers/*
-/ACE*.tar.bz2
+/build/
+/install/
 
 # Generated files
 *.ncb
@@ -84,49 +82,14 @@ ipch
 cmake.cmd
 msbuild.cmd
 
-# cmake generated files in sources
-/dep/ACE_wrappers/ace/ACE_vc8.vcxproj*
-/dep/ACE_wrappers/ace/Backup*
-/dep/ACE_wrappers/ace/Debug*
-/dep/ACE_wrappers/ace/ETCL/ACE_ETCL_Parser_vc8.vcxproj*
-/dep/ACE_wrappers/ace/ETCL/ACE_ETCL_vc8.vcxproj*
-/dep/ACE_wrappers/ace/ETCL/Debug*
-/dep/ACE_wrappers/ace/ETCL/Release*
-/dep/ACE_wrappers/ace/Monitor_Control/Debug*
-/dep/ACE_wrappers/ace/Monitor_Control/Monitor_Control_vc8.vcxproj*
-/dep/ACE_wrappers/ace/Monitor_Control/Release*
-/dep/ACE_wrappers/ace/QoS/Debug*
-/dep/ACE_wrappers/ace/QoS/QoS_vc8.vcxproj*
-/dep/ACE_wrappers/ace/QoS/Release*
-/dep/ACE_wrappers/ace/UpgradeLog*
-/dep/ACE_wrappers/ace/Release*
-/dep/ACE_wrappers/ace/_UpgradeReport_Files*
-/dep/ACE_wrappers/lib/*
-/dep/ACE_wrappers/ace/config.h
-
-# ned files from excluded dirs
-!/dep/ACE_wrappers/ace/ace_message_table.bin
-!/dep/ACE_wrappers/bin/GNUmakefile.bin
-!/dep/ACE_wrappers/configure.ac~
-!/dep/ACE_wrappers/lib/.empty
-!/dep/tbb/src/Makefile
 
 # recastnavigation directory needs exception
 !/dep/recastnavigation/RecastDemo/Build/
-
-# Scripts library directory also needs exceptions
-/src/scripts/ScriptDev2__Win32_Debug/
-/src/scripts/ScriptDev2__Win32_Release/
-/src/scripts/ScriptDev2__x64_Debug/
-/src/scripts/ScriptDev2__x64_Release/
+/database/
 
 /src/tools/Extractor_Binaries/*.exe
 
 # Skip Git Revision created file
-
-
-# File generated during compile
-/dep/libmpq/compile
 
 # Compiler caches. CCACHE_DIR/SCCACHE_DIR in the CI workflows point outside the
 # checkout, which is the actual fix; this is a safety net, because the cache

--- a/src/game/Object/ObjectMgr.cpp
+++ b/src/game/Object/ObjectMgr.cpp
@@ -1437,7 +1437,9 @@ void ObjectMgr::LoadQuestPOI()
 }
 
 
-static char SERVER_SIDE_SPELL[] = "MaNGOS server-side spell";
+// const, so the storage field can only ever be given a copy: SQLStorageBase::Free()
+// delete[]s every string field, and pointing one at this array frees static memory.
+static const char SERVER_SIDE_SPELL[] = "MaNGOS server-side spell";
 
 struct SQLSpellLoader : public SQLStorageLoaderBase<SQLSpellLoader, SQLHashStorage>
 {
@@ -1458,7 +1460,7 @@ struct SQLSpellLoader : public SQLStorageLoaderBase<SQLSpellLoader, SQLHashStora
     {
         if (field_pos == LOADED_SPELLDBC_FIELD_POS_SPELLNAME_0)
         {
-            dst = SERVER_SIDE_SPELL;
+            dst = mangos_strdup(SERVER_SIDE_SPELL);
         }
         else
         {

--- a/src/game/Object/PlayerAreaTrigger.cpp
+++ b/src/game/Object/PlayerAreaTrigger.cpp
@@ -126,11 +126,9 @@ void Player::SendTransferAbortedByLockStatus(MapEntry const* mapEntry, AreaLockS
             break;
         }
         case AREA_LOCKSTATUS_INSUFFICIENT_EXPANSION:
+            // miscRequirement is the expansion number here, not an item id, so
+            // there is no item to name -- TRANSFER_ABORT_INSUF_EXPAN_LVL says it.
             GetSession()->SendTransferAborted(mapEntry->ID, TRANSFER_ABORT_INSUF_EXPAN_LVL, miscRequirement);
-            if (sObjectMgr.GetMapEntranceTrigger(mapEntry->ID))
-            {
-                GetSession()->SendAreaTriggerMessage(GetSession()->GetMangosString(LANG_LEVEL_MINREQUIRED_AND_ITEM), sObjectMgr.GetItemPrototype(miscRequirement)->Name1);
-            }
             break;
         case AREA_LOCKSTATUS_NOT_ALLOWED:
             GetSession()->SendTransferAborted(mapEntry->ID, TRANSFER_ABORT_MAP_NOT_ALLOWED);

--- a/src/game/Server/WorldGateway.cpp
+++ b/src/game/Server/WorldGateway.cpp
@@ -30,7 +30,6 @@
 #include "Common/ServerDefines.h"
 #include "WorldGateway.h"
 
-#include "AddonHandler.h"
 #include "DBCStores.h"
 #include "Database/DatabaseEnv.h"
 #include "Log/Log.h"
@@ -274,15 +273,9 @@ proto::SessionId WorldGateway::Attach(const proto::AuthRequest& request,
     // AddSession answers the client itself, with either AUTH_OK or a queue
     // position. The cipher was armed before we were called, so that reply goes
     // out encrypted -- which is the one ordering constraint across this seam.
+    // AddSession also answers the addon block, via SendAddonsInfo() over the
+    // list ReadAddonsInfo() just parsed -- so nothing more is owed here.
     sWorld.AddSession(session);
-
-    // Reply to the addon block, if the registry produced one.
-    addonPacket.rpos(0);
-    WorldPacket addonResponse;
-    if (sAddOnHandler.BuildAddonPacket(&addonPacket, &addonResponse))
-    {
-        link->SendPacket(addonResponse);
-    }
 
     return id;
 }

--- a/src/game/WorldHandlers/ScriptMgrBinding.cpp
+++ b/src/game/WorldHandlers/ScriptMgrBinding.cpp
@@ -29,6 +29,8 @@
 
 #include <set>
 #include <algorithm>
+#include <mutex>
+#include <shared_mutex>
 #include "ScriptMgr.h"
 #include "Log.h"
 #include "ProgressBar.h"
@@ -179,9 +181,8 @@ void ScriptMgr::LoadScriptBinding()
 bool ScriptMgr::ReloadScriptBinding()
 {
 #ifdef _DEBUG
-    m_bindMutex.acquire_write();
+    std::unique_lock<std::shared_mutex> guard(m_bindMutex);
     LoadScriptBinding();
-    m_bindMutex.release();
     return true;
 #else
     return false;
@@ -259,7 +260,7 @@ uint32 ScriptMgr::GetScriptId(const char* name) const
 uint32 ScriptMgr::GetBoundScriptId(ScriptedObjectType entity, int32 entry)
 {
 #ifdef _DEBUG
-    m_bindMutex.acquire_read();
+    std::shared_lock<std::shared_mutex> guard(m_bindMutex);
 #endif /* _DEBUG */
     uint32 id = 0;
     if (entity < SCRIPTED_MAX_TYPE)
@@ -272,9 +273,6 @@ uint32 ScriptMgr::GetBoundScriptId(ScriptedObjectType entity, int32 entry)
     }
     else
         sLog.outErrorScriptLib("asking a script for non-existing entity type %u!", entity);
-#ifdef _DEBUG
-    m_bindMutex.release();
-#endif /* _DEBUG */
     return id;
 }
 

--- a/src/mangosd/CliService.cpp
+++ b/src/mangosd/CliService.cpp
@@ -25,6 +25,7 @@
 #include "CliService.h"
 
 #include "Common/ServerDefines.h"
+#include "Console/ConsoleUI.h"
 #include "Log.h"
 #include "Util.h"
 #include "World.h"
@@ -53,6 +54,11 @@ namespace
      */
     void Prompt(void* /*callbackArg*/ = nullptr, bool /*success*/ = true)
     {
+        if (MaNGOS::Console::ConsoleUI::Instance().Active())
+        {
+            return;                             // the console draws its own input row
+        }
+
         sLog.ConsoleEmitRaw("mangos>");
     }
 
@@ -126,13 +132,45 @@ void CliService::Run()
     // Let start-up finish printing before the prompt lands in the middle of it.
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
-    if (m_beep)
+    if (m_beep && !MaNGOS::Console::ConsoleUI::Instance().Active())
     {
         sLog.ConsoleEmitRaw("\a");
     }
 
     Prompt();
 
+    if (MaNGOS::Console::ConsoleUI::Instance().Active())
+    {
+        RunManaged();
+    }
+    else
+    {
+        RunLineBased();
+    }
+}
+
+void CliService::RunManaged()
+{
+    std::string line;
+
+    while (!m_stop.load(std::memory_order_acquire) && !World::IsStopped())
+    {
+        // Already UTF-8: the console decodes keystrokes to code points itself, so
+        // the consoleToUtf8() step of the line-based path would double-convert.
+        if (!MaNGOS::Console::ConsoleUI::Instance().PollInput(line))
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(15));
+            continue;
+        }
+
+        sWorld.QueueCliCommand(
+            new CliCommandHolder(0, SEC_CONSOLE, nullptr, line.c_str(),
+                                 &utf8print, &Prompt));
+    }
+}
+
+void CliService::RunLineBased()
+{
     char buffer[256];
 
     while (!m_stop.load(std::memory_order_acquire) && !World::IsStopped())

--- a/src/mangosd/CliService.h
+++ b/src/mangosd/CliService.h
@@ -55,6 +55,12 @@ class CliService : public IService
 
         void Run();
 
+        /// Reader loop for the full-screen console, which owns the keyboard.
+        void RunManaged();
+
+        /// Reader loop for a plain line-oriented terminal (or redirected stdin).
+        void RunLineBased();
+
         const bool        m_beep;
         std::thread       m_thread;
         std::atomic<bool> m_stop;

--- a/src/mangosd/Master.cpp
+++ b/src/mangosd/Master.cpp
@@ -29,6 +29,7 @@
 #include "RASession.h"
 
 #include "Config/Config.h"
+#include "Console/ConsoleUI.h"
 #include "DBCStores.h"
 #include "Database/DatabaseEnv.h"
 #include "Log.h"
@@ -166,7 +167,7 @@ void Master::ClearOnlineAccounts()
     CharacterDatabase.Execute("DELETE FROM `character_battleground_data`");
 
     CharacterDatabase.Execute(
-        "UPDATE `groups` SET `leaderGuid` = (SELECT `guid` FROM `group_member` "
+        "UPDATE `groups` SET `leaderGuid` = (SELECT `memberGuid` FROM `group_member` "
         "WHERE `group_member`.`groupId` = `groups`.`groupId` ORDER BY `memberFlags` DESC LIMIT 1) "
         "WHERE `leaderGuid` NOT IN (SELECT `memberGuid` FROM `group_member` "
         "WHERE `group_member`.`groupId` = `groups`.`groupId`)");
@@ -238,12 +239,41 @@ void Master::StopServices()
     m_services.clear();
 }
 
+void Master::PublishConsoleStatus(uint32 diff)
+{
+    MaNGOS::Console::ConsoleUI& ui = MaNGOS::Console::ConsoleUI::Instance();
+    if (!ui.Active())
+    {
+        return;
+    }
+
+    const uint32 uptime = sWorld.GetUptime();
+    char buf[64];
+
+    snprintf(buf, sizeof(buf), "%u / %u", sWorld.GetActiveSessionCount(),
+             sWorld.GetPlayerAmountLimit());
+    ui.SetStatus(0, "Players", buf);
+
+    ui.SetStatus(1, "Queue", std::to_string(sWorld.GetQueuedSessionCount()),
+                 sWorld.GetQueuedSessionCount() ? MaNGOS::Console::STYLE_WARN
+                                                : MaNGOS::Console::STYLE_NORMAL);
+
+    snprintf(buf, sizeof(buf), "%u ms", diff);
+    ui.SetStatus(2, "Diff", buf, diff > WORLD_SLEEP_CONST ? MaNGOS::Console::STYLE_WARN
+                                                          : MaNGOS::Console::STYLE_SUCCESS);
+
+    snprintf(buf, sizeof(buf), "%ud %02u:%02u:%02u", uptime / 86400,
+             (uptime / 3600) % 24, (uptime / 60) % 60, uptime % 60);
+    ui.SetStatus(3, "Uptime", buf);
+}
+
 void Master::WorldLoop()
 {
     sLog.outString("World updater started (%dms minimum update interval)",
                    WORLD_SLEEP_CONST);
 
     uint32 previous = getMSTime();
+    uint32 lastStatus = 0;
 
     while (!World::IsStopped())
     {
@@ -255,6 +285,13 @@ void Master::WorldLoop()
         previous = current;
 
         const uint32 spent = getMSTimeDiff(current, getMSTime());
+
+        if (getMSTimeDiff(lastStatus, current) >= 1000)
+        {
+            lastStatus = current;
+            PublishConsoleStatus(spent);
+        }
+
         if (spent < WORLD_SLEEP_CONST)
         {
             std::this_thread::sleep_for(

--- a/src/mangosd/Master.h
+++ b/src/mangosd/Master.h
@@ -76,6 +76,10 @@ class Master
         /// The world heartbeat. Returns when World::IsStopped() becomes true.
         void WorldLoop();
 
+        /// Push the once-a-second figures into the full-screen console's status
+        /// region. A no-op when that console is not running.
+        void PublishConsoleStatus(uint32 diff);
+
         /// Everything that must happen after the final world tick.
         void ShutdownWorld();
 

--- a/src/mangosd/mangosd.cpp
+++ b/src/mangosd/mangosd.cpp
@@ -305,10 +305,7 @@ int main(int argc, char** argv)
     DETAIL_LOG("Using SSL version: %s (Library: %s)", OPENSSL_VERSION_TEXT, OpenSSL_version(OPENSSL_VERSION));
 
 #if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
-    // RAII provider management - automatically handles cleanup
-    OpenSSLProviderManager providerManager;
-
-    if (!providerManager.IsInitialized())
+    if (!OpenSSLProviderManager::Instance().IsInitialized())
     {
         Log::WaitBeforeContinueIfNeed();
         return 0;

--- a/src/mangosd/mangosd.cpp
+++ b/src/mangosd/mangosd.cpp
@@ -59,6 +59,7 @@
 #include "Config/Config.h"
 #include "GitRevision.h"
 #include "ProgressBar.h"
+#include "Console/ConsoleUI.h"
 #include "Log.h"
 #include "SystemConfig.h"
 #include "AuctionHouseBot.h"
@@ -180,6 +181,13 @@ static void usage(const char* prog)
 static void MangosBarConsoleSink(char const* bytes, size_t len)
 {
     sLog.ConsoleEmitRaw(std::string(bytes, len));
+}
+
+/// Progress-bar sink for the full-screen console: it draws its own bar, so it
+/// wants the percentage, not a redraw. -1 means the bar finished.
+static void MangosBarProgressSink(int percent)
+{
+    MaNGOS::Console::ConsoleUI::Instance().SetProgress(percent);
 }
 
 /// Launch the mangos server
@@ -317,6 +325,11 @@ int main(int argc, char** argv)
     ///- Set progress bars show mode
     BarGoLink::SetOutputState(sConfig.GetBoolDefault("ShowProgressBars", true));
 
+    // Serialise the bar through the console writer instead of letting it write
+    // straight to stdout from the loading thread: two owners of stdout is what
+    // shreds the start-up log, with bar redraws landing inside log lines.
+    BarGoLink::SetConsoleSink(&MangosBarConsoleSink);
+
     /// worldd PID file creation
     std::string pidfile = sConfig.GetStringDefault("PidFile", "");
     if (!pidfile.empty())
@@ -337,6 +350,22 @@ int main(int argc, char** argv)
     // covered, and after the fallible init above so an early return never leaves
     // a writer thread running into stdio teardown.
     sLog.StartConsoleThread();
+
+    // Only now: until the writer thread exists, console emits take the
+    // synchronous path and would write straight over the full-screen frame.
+    if (sConfig.GetBoolDefault("Console.FullScreen", true) &&
+        MaNGOS::Console::ConsoleUI::Instance().Start("MaNGOS Two", "WotLK 3.3.5a"))
+    {
+        MaNGOS::Console::ConsoleUI::Instance().SetHeaderRight(
+            std::string("realm ") + std::to_string(realmID));
+        MaNGOS::Console::ConsoleUI::Instance().SetHint(
+            "PgUp/PgDn scroll \xC2\xB7 Ctrl+L redraw");
+        MaNGOS::Console::ConsoleUI::Instance().SetKeyEcho(
+            sConfig.GetBoolDefault("Console.DebugKeys", false));
+        MaNGOS::Console::ConsoleUI::Instance().SetScrollback(
+            uint32(sConfig.GetIntDefault("Console.Scrollback", 20000)));
+        BarGoLink::SetProgressSink(&MangosBarProgressSink);
+    }
 
     ///- Catch termination signals
     hook_signals();
@@ -375,6 +404,9 @@ int main(int argc, char** argv)
     // so nothing can race the writer's deletion. The remaining main-thread lines
     // drain through it before it joins; "Bye!" then takes the synchronous path.
     sLog.StopConsoleThread();
+
+    // After the writer is joined, so no repaint can race the terminal restore.
+    MaNGOS::Console::ConsoleUI::Instance().Stop();
 
     sLog.outString("Bye!");
 

--- a/src/proto/ClientConnection.cpp
+++ b/src/proto/ClientConnection.cpp
@@ -108,13 +108,25 @@ namespace proto
             return std::vector<uint8_t>();
         }
 
-        for (size_t i = 0; i < packets.size(); ++i)
+        // A short read anywhere below unwinds onto a network worker thread, where
+        // nothing else would catch it and the process would abort. Dropping the
+        // peer has to be the worst a malformed packet can do.
+        try
         {
-            if (!HandlePacket(std::move(packets[i])))
+            for (size_t i = 0; i < packets.size(); ++i)
             {
-                Close();
-                break;
+                if (!HandlePacket(std::move(packets[i])))
+                {
+                    Close();
+                    break;
+                }
             }
+        }
+        catch (ByteBufferException&)
+        {
+            sLog.outError("proto: short read handling packet from %s, dropping",
+                          m_address.c_str());
+            Close();
         }
 
         // Everything this class sends goes through SendPacket() (and therefore the

--- a/src/shared/Auth/ARC4.cpp
+++ b/src/shared/Auth/ARC4.cpp
@@ -55,8 +55,8 @@
 ARC4::ARC4(uint8 len) : m_cipherContext()
 {
 #if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
-    // Provider management is now handled by OpenSSLProviderManager
-    if (!m_providerManager.IsInitialized())
+    // RC4 lives in the legacy provider, so it has to be loaded before EVP_rc4().
+    if (!OpenSSLProviderManager::Instance().IsInitialized())
     {
         sLog.outError("ARC4: Failed to initialize OpenSSL providers");
         return;
@@ -88,8 +88,8 @@ ARC4::ARC4(uint8 len) : m_cipherContext()
 ARC4::ARC4(uint8 *seed, uint8 len) : m_cipherContext()
 {
 #if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
-    // Provider management is now handled by OpenSSLProviderManager
-    if (!m_providerManager.IsInitialized())
+    // RC4 lives in the legacy provider, so it has to be loaded before EVP_rc4().
+    if (!OpenSSLProviderManager::Instance().IsInitialized())
     {
         sLog.outError("ARC4: Failed to initialize OpenSSL providers");
         return;

--- a/src/shared/Auth/ARC4.h
+++ b/src/shared/Auth/ARC4.h
@@ -66,9 +66,6 @@ class ARC4
          */
         void UpdateData(int len, uint8 *data);
     private:
-#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
-        OpenSSLProviderManager m_providerManager;  /**< RAII provider management */
-#endif
         OpenSSLCipherContext m_cipherContext;        /**< RAII cipher context */
 };
 

--- a/src/shared/Auth/OpenSSLProvider.cpp
+++ b/src/shared/Auth/OpenSSLProvider.cpp
@@ -169,6 +169,12 @@ OpenSSLProviderManager::OpenSSLProviderManager()
     }
 }
 
+OpenSSLProviderManager& OpenSSLProviderManager::Instance()
+{
+    static OpenSSLProviderManager instance;
+    return instance;
+}
+
 /**
  * Logs provider shutdown when the OpenSSL provider manager is destroyed.
  */

--- a/src/shared/Auth/OpenSSLProvider.h
+++ b/src/shared/Auth/OpenSSLProvider.h
@@ -163,6 +163,14 @@ public:
     ~OpenSSLProviderManager();
 
     /**
+     * @brief The one manager for the process
+     *
+     * Providers are global to the library, so loading them per object costs an
+     * OpenSSL-wide lock on every construction and buys nothing.
+     */
+    static OpenSSLProviderManager& Instance();
+
+    /**
      * @brief Check if providers are successfully loaded
      * @return true if both providers loaded successfully
      */

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -53,6 +53,14 @@ set(SRC_GRP_CONFIG
 )
 source_group("Config" FILES ${SRC_GRP_CONFIG})
 
+set(SRC_GRP_CONSOLE
+  Console/ConsoleUI.cpp
+  Console/ConsoleUI.h
+  Console/Terminal.cpp
+  Console/Terminal.h
+)
+source_group("Console" FILES ${SRC_GRP_CONSOLE})
+
 set(SRC_GRP_DATASTORE
   DataStores/DBCFileLoader.cpp
   DataStores/DBCFileLoader.h
@@ -210,6 +218,7 @@ set(TGT_INCL
   Auth
   Common
   Config
+  Console
   DataStores
   Database
   Linux
@@ -234,6 +243,7 @@ add_library(shared STATIC
     ${SRC_GRP_AUTH}
     ${SRC_GRP_COMMON}
     ${SRC_GRP_CONFIG}
+    ${SRC_GRP_CONSOLE}
     ${SRC_GRP_DATASTORE}
     ${SRC_GRP_DATABASE}
     ${SRC_GRP_DYNAMIC}

--- a/src/shared/Console/ConsoleUI.cpp
+++ b/src/shared/Console/ConsoleUI.cpp
@@ -1,0 +1,880 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "ConsoleUI.h"
+#include "Terminal.h"
+
+#include <algorithm>
+#include <cstdio>
+
+namespace MaNGOS
+{
+namespace Console
+{
+
+namespace
+{
+    const char* const SGR_RESET   = "\x1b[0m";
+    const char* const SGR_RULE    = "\x1b[38;5;238m";
+    const char* const SGR_TITLE   = "\x1b[1;38;5;81m";
+    const char* const SGR_SUB     = "\x1b[38;5;244m";
+    const char* const SGR_LABEL   = "\x1b[38;5;245m";
+    const char* const SGR_VALUE   = "\x1b[1;38;5;252m";
+    const char* const SGR_TIME    = "\x1b[38;5;240m";
+    const char* const SGR_BARFULL = "\x1b[38;5;73m";
+    const char* const SGR_BAREMPT = "\x1b[38;5;237m";
+    const char* const SGR_PROMPT  = "\x1b[1;38;5;114m";
+
+    const char* const GLYPH_RULE  = "\xE2\x94\x80";   // U+2500
+    const char* const GLYPH_FULL  = "\xE2\x96\x88";   // U+2588
+    const char* const GLYPH_EMPTY = "\xE2\x96\x91";   // U+2591
+    const char* const GLYPH_DOT   = "\xC2\xB7";       // U+00B7
+
+    const char* StyleSgr(Style s)
+    {
+        switch (s)
+        {
+        case STYLE_DETAIL:  return "\x1b[38;5;109m";
+        case STYLE_DEBUG:   return "\x1b[38;5;140m";
+        case STYLE_SUCCESS: return "\x1b[38;5;114m";
+        case STYLE_WARN:    return "\x1b[38;5;179m";
+        case STYLE_ERROR:   return "\x1b[1;38;5;203m";
+        case STYLE_ACCENT:  return "\x1b[38;5;81m";
+        case STYLE_NORMAL:
+        default:            return "\x1b[38;5;252m";
+        }
+    }
+
+    std::size_t Utf8SeqLen(unsigned char lead)
+    {
+        if (lead < 0x80)          { return 1; }
+        if ((lead & 0xE0) == 0xC0) { return 2; }
+        if ((lead & 0xF0) == 0xE0) { return 3; }
+        if ((lead & 0xF8) == 0xF0) { return 4; }
+        return 1;
+    }
+
+    void AppendCodePoint(std::string& s, int cp)
+    {
+        if (cp < 0x80)
+        {
+            s += char(cp);
+        }
+        else if (cp < 0x800)
+        {
+            s += char(0xC0 | (cp >> 6));
+            s += char(0x80 | (cp & 0x3F));
+        }
+        else if (cp < 0x10000)
+        {
+            s += char(0xE0 | (cp >> 12));
+            s += char(0x80 | ((cp >> 6) & 0x3F));
+            s += char(0x80 | (cp & 0x3F));
+        }
+        else
+        {
+            s += char(0xF0 | (cp >> 18));
+            s += char(0x80 | ((cp >> 12) & 0x3F));
+            s += char(0x80 | ((cp >> 6) & 0x3F));
+            s += char(0x80 | (cp & 0x3F));
+        }
+    }
+
+    std::size_t PrevBoundary(const std::string& s, std::size_t pos)
+    {
+        while (pos > 0)
+        {
+            --pos;
+            if ((static_cast<unsigned char>(s[pos]) & 0xC0) != 0x80)
+            {
+                break;
+            }
+        }
+        return pos;
+    }
+
+    std::size_t NextBoundary(const std::string& s, std::size_t pos)
+    {
+        if (pos >= s.size())
+        {
+            return s.size();
+        }
+        const std::size_t n = Utf8SeqLen(static_cast<unsigned char>(s[pos]));
+        return std::min(s.size(), pos + n);
+    }
+
+    int CountCodePoints(const std::string& s, std::size_t upto)
+    {
+        int n = 0;
+        for (std::size_t i = 0; i < upto && i < s.size(); i = NextBoundary(s, i))
+        {
+            ++n;
+        }
+        return n;
+    }
+
+    /// Strip anything that would move the cursor or open an escape sequence.
+    std::string Sanitise(const std::string& in)
+    {
+        std::string out;
+        out.reserve(in.size());
+        for (std::size_t i = 0; i < in.size(); ++i)
+        {
+            const unsigned char c = static_cast<unsigned char>(in[i]);
+            if (c == '\t')
+            {
+                out.append(4, ' ');
+            }
+            else if (c >= 32 && c != 127)
+            {
+                out += char(c);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * @brief Fixed-width row assembler.
+     *
+     * Tracks the visible column while appending, so styling is free (zero
+     * width) and text is clipped at the terminal edge instead of wrapping --
+     * a wrapped row would desynchronise every row index below it.
+     */
+    class RowBuilder
+    {
+        public:
+            explicit RowBuilder(int width) : m_col(0), m_max(width)
+            {
+                m_out.reserve(std::size_t(width) * 2 + 16);
+            }
+
+            void Sgr(const char* seq) { m_out += seq; }
+
+            void Text(const std::string& s)
+            {
+                for (std::size_t i = 0; i < s.size() && m_col < m_max; )
+                {
+                    const std::size_t n = Utf8SeqLen(static_cast<unsigned char>(s[i]));
+                    if (i + n > s.size())
+                    {
+                        break;
+                    }
+                    m_out.append(s, i, n);
+                    i += n;
+                    ++m_col;
+                }
+            }
+
+            void Glyph(const char* g, int count)
+            {
+                while (count-- > 0 && m_col < m_max)
+                {
+                    m_out += g;
+                    ++m_col;
+                }
+            }
+
+            void PadTo(int col)
+            {
+                while (m_col < col && m_col < m_max)
+                {
+                    m_out += ' ';
+                    ++m_col;
+                }
+            }
+
+            int Col() const  { return m_col; }
+            int Left() const { return m_max - m_col; }
+
+            std::string Take()
+            {
+                m_out += SGR_RESET;
+                return m_out;
+            }
+
+        private:
+            std::string m_out;
+            int         m_col;
+            int         m_max;
+    };
+
+    std::string MakeRule(int cols)
+    {
+        RowBuilder b(cols);
+        b.Sgr(SGR_RULE);
+        b.Glyph(GLYPH_RULE, cols);
+        return b.Take();
+    }
+
+    /// Length of a leading "HH:MM:SS " stamp, or 0 when the line has none.
+    std::size_t TimeStampLen(const std::string& s)
+    {
+        if (s.size() < 9)
+        {
+            return 0;
+        }
+        for (int i = 0; i < 8; ++i)
+        {
+            const char c = s[std::size_t(i)];
+            const bool wantColon = (i == 2 || i == 5);
+            if (wantColon ? (c != ':') : (c < '0' || c > '9'))
+            {
+                return 0;
+            }
+        }
+        return (s[8] == ' ') ? 9 : 0;
+    }
+}
+
+ConsoleUI::ConsoleUI()
+    : m_active(false),
+      m_forceRedraw(true),
+      m_rows(0),
+      m_cols(0),
+      m_prompt("mangos> "),
+      m_progress(-1),
+      m_keyEcho(false),
+      m_lastKey(0),
+      m_scrollback(DEFAULT_SCROLLBACK),
+      m_scroll(0),
+      m_cursor(0),
+      m_historyPos(-1),
+      m_cursorCol(0)
+{
+}
+
+ConsoleUI& ConsoleUI::Instance()
+{
+    static ConsoleUI instance;
+    return instance;
+}
+
+bool ConsoleUI::Start(const std::string& title, const std::string& subtitle)
+{
+    std::lock_guard<std::mutex> guard(m_mutex);
+
+    if (m_active)
+    {
+        return true;
+    }
+    if (!Terminal::Enter())
+    {
+        return false;
+    }
+
+    m_title       = title;
+    m_subtitle    = subtitle;
+    m_active      = true;
+    m_forceRedraw = true;
+    return true;
+}
+
+void ConsoleUI::Stop()
+{
+    std::deque<LogLine> tail;
+    {
+        std::lock_guard<std::mutex> guard(m_mutex);
+        if (!m_active)
+        {
+            return;
+        }
+        m_active = false;
+
+        const std::size_t keep = std::min<std::size_t>(m_log.size(), 25);
+        tail.assign(m_log.end() - std::ptrdiff_t(keep), m_log.end());
+    }
+
+    Terminal::Leave();
+
+    // The alternate screen took the session's output with it; replay the tail so
+    // the operator is not left staring at a blank shell after a shutdown.
+    for (std::deque<LogLine>::const_iterator it = tail.begin(); it != tail.end(); ++it)
+    {
+        fwrite(it->text.data(), 1, it->text.size(), stdout);
+        fputc('\n', stdout);
+    }
+    fflush(stdout);
+}
+
+void ConsoleUI::PushLog(const std::string& text, Style style)
+{
+    std::lock_guard<std::mutex> guard(m_mutex);
+
+    // One log call is not one row: banners and summaries are written as a single
+    // outString() holding a dozen embedded newlines. Splitting here is what keeps
+    // them readable -- Sanitise() drops the '\n' itself, so anything not split
+    // first collapses into one unreadable row.
+    std::string::size_type start = 0;
+    for (std::string::size_type nl = text.find('\n');
+         nl != std::string::npos;
+         nl = text.find('\n', start))
+    {
+        AppendLog(text.substr(start, nl - start), style);
+        start = nl + 1;
+    }
+
+    AppendLog(text.substr(start), style);
+}
+
+void ConsoleUI::AppendLog(const std::string& text, Style style)
+{
+    LogLine line;
+    line.text  = Sanitise(text);
+    line.style = style;
+    m_log.push_back(line);
+
+    while (m_log.size() > m_scrollback)
+    {
+        m_log.pop_front();
+    }
+
+    if (m_scroll > 0)
+    {
+        ++m_scroll;                                     // keep the view pinned while scrolled back
+    }
+}
+
+void ConsoleUI::PushRaw(const std::string& bytes, Style style)
+{
+    PushLog(bytes, style);
+}
+
+void ConsoleUI::SetStatus(unsigned slot, const std::string& label,
+                          const std::string& value, Style style)
+{
+    if (slot >= MAX_STATUS_FIELDS)
+    {
+        return;
+    }
+
+    std::lock_guard<std::mutex> guard(m_mutex);
+    m_status[slot].label = Sanitise(label);
+    m_status[slot].value = Sanitise(value);
+    m_status[slot].style = style;
+    m_status[slot].set   = true;
+}
+
+void ConsoleUI::SetActivity(const std::string& text)
+{
+    std::lock_guard<std::mutex> guard(m_mutex);
+    m_activity = Sanitise(text);
+}
+
+void ConsoleUI::SetProgress(int percent)
+{
+    std::lock_guard<std::mutex> guard(m_mutex);
+
+    // A bar starting is the caller's last log line coming true ("Loading X..."),
+    // which is the only label available: loaders announce the work then open a
+    // bar that knows nothing about it.
+    if (percent == 0 && m_progress < 0 && !m_log.empty())
+    {
+        const std::string& last = m_log.back().text;
+        m_activity = last.substr(TimeStampLen(last));
+    }
+    else if (percent < 0)
+    {
+        m_activity.clear();
+    }
+
+    m_progress = (percent > 100) ? 100 : percent;
+}
+
+void ConsoleUI::SetPrompt(const std::string& prompt)
+{
+    std::lock_guard<std::mutex> guard(m_mutex);
+    m_prompt = Sanitise(prompt);
+}
+
+void ConsoleUI::SetHint(const std::string& hint)
+{
+    std::lock_guard<std::mutex> guard(m_mutex);
+    m_hint = Sanitise(hint);
+}
+
+void ConsoleUI::SetKeyEcho(bool on)
+{
+    std::lock_guard<std::mutex> guard(m_mutex);
+    m_keyEcho = on;
+}
+
+void ConsoleUI::SetScrollback(unsigned lines)
+{
+    std::lock_guard<std::mutex> guard(m_mutex);
+    m_scrollback = (lines < 100) ? 100 : lines;
+
+    while (m_log.size() > m_scrollback)
+    {
+        m_log.pop_front();
+    }
+}
+
+void ConsoleUI::SetHeaderRight(const std::string& text)
+{
+    std::lock_guard<std::mutex> guard(m_mutex);
+    m_headerRight = Sanitise(text);
+}
+
+bool ConsoleUI::PollInput(std::string& line)
+{
+    if (!m_active)
+    {
+        return false;
+    }
+
+    // Drained before taking the lock on purpose: decoding an escape sequence or a
+    // multi-byte character polls stdin for up to 25ms per byte, and holding the
+    // mutex across that would stall the render thread on every arrow key.
+    int keys[64];
+    int count = 0;
+    while (count < 64)
+    {
+        const int key = Terminal::ReadKey();
+        if (key == KEY_NONE)
+        {
+            break;
+        }
+        keys[count++] = key;
+    }
+
+    std::lock_guard<std::mutex> guard(m_mutex);
+
+    for (int i = 0; i < count; ++i)
+    {
+        HandleKey(keys[i]);
+    }
+
+    if (m_submitted.empty())
+    {
+        return false;
+    }
+
+    line = m_submitted.front();
+    m_submitted.pop_front();
+    return true;
+}
+
+void ConsoleUI::HandleKey(int key)
+{
+    m_lastKey = key;
+
+    switch (key)
+    {
+    case KEY_ENTER:     Submit();                break;
+    case KEY_BACKSPACE: EraseBefore();           break;
+    case KEY_DELETE:    EraseAt();               break;
+    case KEY_LEFT:      MoveLeft();              break;
+    case KEY_RIGHT:     MoveRight();             break;
+    case KEY_UP:        RecallHistory(1);        break;
+    case KEY_DOWN:      RecallHistory(-1);       break;
+    case KEY_HOME:      m_cursor = 0;            break;
+    case KEY_END:       m_cursor = m_input.size(); break;
+    case KEY_RESIZE:    m_forceRedraw = true;    break;
+
+    // Repainting an already-correct frame is invisible, so this also snaps back
+    // to the newest line -- otherwise the key looks dead to whoever pressed it.
+    case KEY_REDRAW:
+        m_forceRedraw = true;
+        m_scroll      = 0;
+        break;
+
+    case KEY_PAGEUP:
+        m_scroll += 10;
+        break;
+
+    case KEY_PAGEDOWN:
+        m_scroll = (m_scroll > 10) ? m_scroll - 10 : 0;
+        break;
+
+    case KEY_KILLLINE:
+        m_input.erase(0, m_cursor);
+        m_cursor = 0;
+        break;
+
+    case KEY_KILLWORD:
+        while (m_cursor > 0 && m_input[PrevBoundary(m_input, m_cursor)] == ' ')
+        {
+            EraseBefore();
+        }
+        while (m_cursor > 0 && m_input[PrevBoundary(m_input, m_cursor)] != ' ')
+        {
+            EraseBefore();
+        }
+        break;
+
+    case KEY_TAB:
+    case KEY_EOF:
+    case KEY_NONE:
+        break;
+
+    default:
+        if (key > 0)
+        {
+            InsertCodePoint(key);
+        }
+        break;
+    }
+}
+
+void ConsoleUI::InsertCodePoint(int cp)
+{
+    std::string encoded;
+    AppendCodePoint(encoded, cp);
+    m_input.insert(m_cursor, encoded);
+    m_cursor += encoded.size();
+}
+
+void ConsoleUI::EraseBefore()
+{
+    if (m_cursor == 0)
+    {
+        return;
+    }
+    const std::size_t start = PrevBoundary(m_input, m_cursor);
+    m_input.erase(start, m_cursor - start);
+    m_cursor = start;
+}
+
+void ConsoleUI::EraseAt()
+{
+    if (m_cursor >= m_input.size())
+    {
+        return;
+    }
+    const std::size_t end = NextBoundary(m_input, m_cursor);
+    m_input.erase(m_cursor, end - m_cursor);
+}
+
+void ConsoleUI::MoveLeft()
+{
+    m_cursor = PrevBoundary(m_input, m_cursor);
+}
+
+void ConsoleUI::MoveRight()
+{
+    m_cursor = NextBoundary(m_input, m_cursor);
+}
+
+void ConsoleUI::RecallHistory(int delta)
+{
+    if (m_history.empty())
+    {
+        return;
+    }
+
+    int pos = m_historyPos + delta;
+    pos = std::max(-1, std::min(pos, int(m_history.size()) - 1));
+
+    m_historyPos = pos;
+    m_input      = (pos < 0) ? std::string() : m_history[m_history.size() - 1 - std::size_t(pos)];
+    m_cursor     = m_input.size();
+}
+
+void ConsoleUI::Submit()
+{
+    if (!m_input.empty())
+    {
+        m_history.push_back(m_input);
+        m_submitted.push_back(m_input);
+        AppendLog(m_prompt + m_input, STYLE_ACCENT);
+    }
+
+    m_input.clear();
+    m_cursor     = 0;
+    m_historyPos = -1;
+    m_scroll     = 0;
+}
+
+void ConsoleUI::ComposeHeader(std::vector<std::string>& frame, int cols)
+{
+    RowBuilder b(cols);
+    b.PadTo(1);
+    b.Sgr(SGR_TITLE);
+    b.Text(m_title);
+
+    if (!m_subtitle.empty())
+    {
+        b.Sgr(SGR_SUB);
+        b.Text(" ");
+        b.Glyph(GLYPH_DOT, 1);
+        b.Text(" ");
+        b.Text(m_subtitle);
+    }
+
+    if (!m_headerRight.empty())
+    {
+        const int want = cols - 1 - CountCodePoints(m_headerRight, m_headerRight.size());
+        if (want > b.Col())
+        {
+            b.PadTo(want);
+            b.Sgr(SGR_SUB);
+            b.Text(m_headerRight);
+        }
+    }
+
+    frame.push_back(b.Take());
+    frame.push_back(MakeRule(cols));
+}
+
+void ConsoleUI::ComposeStatus(std::vector<std::string>& frame, int cols)
+{
+    const int fieldWidth = 22;
+
+    std::vector<const StatusField*> fields;
+    for (unsigned i = 0; i < MAX_STATUS_FIELDS; ++i)
+    {
+        if (m_status[i].set)
+        {
+            fields.push_back(&m_status[i]);
+        }
+    }
+
+    if (!fields.empty())
+    {
+        RowBuilder b(cols);
+
+        for (std::size_t i = 0; i < fields.size(); ++i)
+        {
+            b.PadTo(2 + int(i) * fieldWidth);
+            b.Sgr(SGR_LABEL);
+            b.Text(fields[i]->label);
+            b.Text("  ");
+            b.Sgr(fields[i]->style == STYLE_NORMAL ? SGR_VALUE
+                                                   : StyleSgr(fields[i]->style));
+            b.Text(fields[i]->value);
+        }
+
+        frame.push_back(b.Take());
+    }
+
+    if (m_progress >= 0 || !m_activity.empty())
+    {
+        const int barWidth = std::max(10, std::min(32, cols / 3));
+        RowBuilder b(cols);
+        b.PadTo(1);
+        b.Sgr(StyleSgr(STYLE_ACCENT));
+        b.Text(m_activity);
+
+        if (m_progress >= 0)
+        {
+            const int barStart = cols - barWidth - 7;
+            if (barStart > b.Col() + 1)
+            {
+                b.PadTo(barStart);
+                const int filled = m_progress * barWidth / 100;
+                b.Sgr(SGR_BARFULL);
+                b.Glyph(GLYPH_FULL, filled);
+                b.Sgr(SGR_BAREMPT);
+                b.Glyph(GLYPH_EMPTY, barWidth - filled);
+                b.Sgr(SGR_VALUE);
+                char pct[8];
+                snprintf(pct, sizeof(pct), " %3d%%", m_progress);
+                b.Text(pct);
+            }
+        }
+
+        frame.push_back(b.Take());
+    }
+
+    frame.push_back(MakeRule(cols));
+}
+
+void ConsoleUI::ComposeLog(std::vector<std::string>& frame, int cols, int height)
+{
+    if (height <= 0)
+    {
+        return;
+    }
+
+    const int total   = int(m_log.size());
+    const int maxBack = std::max(0, total - height);
+    if (m_scroll > maxBack)
+    {
+        m_scroll = maxBack;
+    }
+
+    const int last  = total - m_scroll;
+    const int first = std::max(0, last - height);
+
+    for (int i = first; i < last; ++i)
+    {
+        const LogLine& line = m_log[std::size_t(i)];
+        RowBuilder b(cols);
+        b.PadTo(1);
+
+        const std::size_t stamp = TimeStampLen(line.text);
+        if (stamp)
+        {
+            b.Sgr(SGR_TIME);
+            b.Text(line.text.substr(0, stamp));
+        }
+
+        b.Sgr(StyleSgr(line.style));
+        b.Text(line.text.substr(stamp));
+        frame.push_back(b.Take());
+    }
+
+    for (int i = last - first; i < height; ++i)
+    {
+        frame.push_back(std::string(SGR_RESET));
+    }
+}
+
+void ConsoleUI::ComposeInput(std::vector<std::string>& frame, int cols)
+{
+    RowBuilder b(cols);
+    b.PadTo(1);
+    b.Sgr(SGR_PROMPT);
+    b.Text(m_prompt);
+
+    m_cursorCol = std::min(cols - 1, b.Col() + CountCodePoints(m_input, m_cursor));
+
+    b.Sgr(SGR_RESET);
+    b.Text(m_input);
+
+    std::string right = m_hint;
+    if (m_scroll > 0)
+    {
+        char note[48];
+        snprintf(note, sizeof(note), "scrolled back %d line(s)", m_scroll);
+        right = note;
+    }
+    if (m_keyEcho)
+    {
+        char note[48];
+        snprintf(note, sizeof(note), "key %d  scroll %d  lines %d",
+                 m_lastKey, m_scroll, int(m_log.size()));
+        right = note;
+    }
+
+    if (!right.empty())
+    {
+        const int want = cols - 1 - CountCodePoints(right, right.size());
+        if (want > b.Col() + 2)
+        {
+            b.PadTo(want);
+            b.Sgr(SGR_TIME);
+            b.Text(right);
+        }
+    }
+
+    frame.push_back(b.Take());
+}
+
+void ConsoleUI::ComposeFrame(std::vector<std::string>& frame, int rows, int cols)
+{
+    frame.clear();
+    frame.reserve(std::size_t(rows));
+
+    ComposeHeader(frame, cols);
+    ComposeStatus(frame, cols);
+
+    const int chrome    = int(frame.size()) + 2;
+    const int logHeight = std::max(0, rows - chrome);
+
+    ComposeLog(frame, cols, logHeight);
+    frame.push_back(MakeRule(cols));
+    ComposeInput(frame, cols);
+
+    frame.resize(std::size_t(rows), std::string(SGR_RESET));
+}
+
+void ConsoleUI::Render()
+{
+    if (!m_active)
+    {
+        return;
+    }
+
+    int rows = 0;
+    int cols = 0;
+    Terminal::Size(rows, cols);
+
+    std::string out;
+    {
+        std::lock_guard<std::mutex> guard(m_mutex);
+
+        // Re-checked under the lock: Stop() may have restored the terminal
+        // between the early-out above and here, and this would then paint
+        // escape sequences onto the operator's shell.
+        if (!m_active)
+        {
+            return;
+        }
+
+        if (rows != m_rows || cols != m_cols)
+        {
+            m_rows        = rows;
+            m_cols        = cols;
+            m_forceRedraw = true;
+            m_frame.clear();
+        }
+
+        if (rows < 8 || cols < 40)
+        {
+            return;
+        }
+
+        std::vector<std::string> frame;
+        ComposeFrame(frame, rows, cols);
+
+        if (m_forceRedraw)
+        {
+            out += "\x1b[2J";
+        }
+
+        for (std::size_t r = 0; r < frame.size(); ++r)
+        {
+            if (!m_forceRedraw && r < m_frame.size() && m_frame[r] == frame[r])
+            {
+                continue;
+            }
+            out += "\x1b[";
+            out += std::to_string(r + 1);
+            out += ";1H";
+            out += frame[r];
+            out += "\x1b[K";
+        }
+
+        m_frame.swap(frame);
+        m_forceRedraw = false;
+
+        out += "\x1b[";
+        out += std::to_string(rows);
+        out += ";";
+        out += std::to_string(m_cursorCol + 1);
+        out += "H";
+    }
+
+    if (!out.empty())
+    {
+        // Hidden across the repaint so the caret does not streak over every row
+        // being painted, then shown where it was parked: the terminal's own
+        // cursor, which blinks and matches what the operator expects.
+        Terminal::Write("\x1b[?25l" + out + "\x1b[?25h");
+    }
+}
+
+}
+}

--- a/src/shared/Console/ConsoleUI.cpp
+++ b/src/shared/Console/ConsoleUI.cpp
@@ -867,13 +867,10 @@ void ConsoleUI::Render()
         out += "H";
     }
 
-    if (!out.empty())
-    {
-        // Hidden across the repaint so the caret does not streak over every row
-        // being painted, then shown where it was parked: the terminal's own
-        // cursor, which blinks and matches what the operator expects.
-        Terminal::Write("\x1b[?25l" + out + "\x1b[?25h");
-    }
+    // Hidden across the repaint so the caret does not streak over every row being
+    // painted, then shown where it was parked: the terminal's own cursor, which
+    // blinks and matches what the operator expects.
+    Terminal::Write("\x1b[?25l" + out + "\x1b[?25h");
 }
 
 }

--- a/src/shared/Console/ConsoleUI.h
+++ b/src/shared/Console/ConsoleUI.h
@@ -25,6 +25,7 @@
 #ifndef MANGOS_H_CONSOLE_CONSOLEUI
 #define MANGOS_H_CONSOLE_CONSOLEUI
 
+#include <atomic>
 #include <deque>
 #include <mutex>
 #include <string>
@@ -166,7 +167,9 @@ namespace Console
             void ComposeInput(std::vector<std::string>& frame, int cols);
 
             mutable std::mutex      m_mutex;
-            bool                    m_active;
+            /// Read without m_mutex by the log writer and the CLI thread, while
+            /// Stop() clears it from the main thread -- so it has to be atomic.
+            std::atomic<bool>       m_active;
             bool                    m_forceRedraw;
             int                     m_rows;
             int                     m_cols;

--- a/src/shared/Console/ConsoleUI.h
+++ b/src/shared/Console/ConsoleUI.h
@@ -1,0 +1,201 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_H_CONSOLE_CONSOLEUI
+#define MANGOS_H_CONSOLE_CONSOLEUI
+
+#include <deque>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace MaNGOS
+{
+namespace Console
+{
+    /**
+     * @brief Semantic weight of a line, resolved to colour by the theme.
+     *
+     * Callers name intent, never a colour, so the palette is decided in exactly
+     * one place and stays coherent across the three regions.
+     */
+    enum Style
+    {
+        STYLE_NORMAL,
+        STYLE_DETAIL,
+        STYLE_DEBUG,
+        STYLE_SUCCESS,
+        STYLE_WARN,
+        STYLE_ERROR,
+        STYLE_ACCENT
+    };
+
+    enum
+    {
+        MAX_STATUS_FIELDS   = 12,
+        DEFAULT_SCROLLBACK  = 20000
+    };
+
+    /**
+     * @brief Full-screen console: status header, scrollback log, command line.
+     *
+     * Three regions on one alternate screen. Producers (any thread) only push
+     * state; the single render thread turns that state into a frame and writes
+     * the rows that actually changed, so nothing flickers and no producer ever
+     * blocks on the terminal.
+     *
+     * Game-agnostic on purpose: it takes strings and numbers and knows nothing
+     * about worlds, players or maps. What to display is the caller's decision.
+     */
+    class ConsoleUI
+    {
+        public:
+            static ConsoleUI& Instance();
+
+            /**
+             * @brief Take over the terminal.
+             * @return false when the process has no terminal to take over, and
+             *         the caller must keep using line-oriented output.
+             */
+            bool Start(const std::string& title, const std::string& subtitle);
+
+            /// Restore the terminal and replay the log tail onto the normal screen.
+            void Stop();
+
+            bool Active() const { return m_active; }
+
+            void PushLog(const std::string& text, Style style);
+
+            /**
+             * @brief Push verbatim console bytes, split into lines.
+             *
+             * For output that was written for a line-oriented console and still
+             * carries its own newlines (CLI command results). Embedded control
+             * bytes are dropped rather than replayed.
+             */
+            void PushRaw(const std::string& bytes, Style style);
+
+            void SetStatus(unsigned slot, const std::string& label,
+                           const std::string& value, Style style = STYLE_NORMAL);
+
+            /// Current long-running operation shown next to the progress bar.
+            void SetActivity(const std::string& text);
+
+            /// 0..100 draws the bar; a negative value hides it.
+            void SetProgress(int percent);
+
+            void SetPrompt(const std::string& prompt);
+            void SetHint(const std::string& hint);
+
+            /// Show the code of each keystroke in the input row. Diagnostic only.
+            void SetKeyEcho(bool on);
+
+            /// Lines of history kept. Trims immediately when lowered.
+            void SetScrollback(unsigned lines);
+            void SetHeaderRight(const std::string& text);
+
+            /**
+             * @brief Drain the keyboard and hand back one finished command line.
+             *
+             * Non-blocking, and the only entry point that touches stdin. Call it
+             * from the one thread that consumes commands.
+             *
+             * @return true when @p line was filled with a submitted command.
+             */
+            bool PollInput(std::string& line);
+
+            /// Build a frame and emit the changed rows. Render thread only.
+            void Render();
+
+        private:
+            ConsoleUI();
+
+            struct LogLine
+            {
+                std::string text;
+                Style       style;
+            };
+
+            struct StatusField
+            {
+                std::string label;
+                std::string value;
+                Style       style;
+                bool        set;
+
+                StatusField() : style(STYLE_NORMAL), set(false) {}
+            };
+
+            /// Append to the scrollback. Caller must hold m_mutex.
+            void AppendLog(const std::string& text, Style style);
+
+            void HandleKey(int key);
+            void InsertCodePoint(int cp);
+            void EraseBefore();
+            void EraseAt();
+            void MoveLeft();
+            void MoveRight();
+            void RecallHistory(int delta);
+            void Submit();
+
+            void ComposeFrame(std::vector<std::string>& frame, int rows, int cols);
+            void ComposeHeader(std::vector<std::string>& frame, int cols);
+            void ComposeStatus(std::vector<std::string>& frame, int cols);
+            void ComposeLog(std::vector<std::string>& frame, int cols, int height);
+            void ComposeInput(std::vector<std::string>& frame, int cols);
+
+            mutable std::mutex      m_mutex;
+            bool                    m_active;
+            bool                    m_forceRedraw;
+            int                     m_rows;
+            int                     m_cols;
+
+            std::string             m_title;
+            std::string             m_subtitle;
+            std::string             m_headerRight;
+            std::string             m_activity;
+            std::string             m_hint;
+            std::string             m_prompt;
+            int                     m_progress;
+            bool                    m_keyEcho;
+            int                     m_lastKey;
+
+            StatusField             m_status[MAX_STATUS_FIELDS];
+            std::deque<LogLine>     m_log;
+            std::size_t             m_scrollback;
+            int                     m_scroll;
+
+            std::string             m_input;
+            std::size_t             m_cursor;
+            std::vector<std::string> m_history;
+            int                     m_historyPos;
+            std::deque<std::string> m_submitted;
+
+            std::vector<std::string> m_frame;
+            int                     m_cursorCol;
+    };
+}
+}
+
+#endif

--- a/src/shared/Console/Terminal.cpp
+++ b/src/shared/Console/Terminal.cpp
@@ -1,0 +1,459 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "Terminal.h"
+
+#include <cstdio>
+
+#ifdef _WIN32
+#  include <windows.h>
+#  include <io.h>
+#else
+#  include <termios.h>
+#  include <unistd.h>
+#  include <poll.h>
+#  include <sys/ioctl.h>
+#endif
+
+namespace MaNGOS
+{
+namespace Console
+{
+
+namespace
+{
+    bool s_active = false;
+
+    const char ENTER_SEQ[] = "\x1b[?1049h\x1b[?25l\x1b[2J";
+    const char LEAVE_SEQ[] = "\x1b[0m\x1b[?25h\x1b[?1049l";
+
+#ifdef _WIN32
+    HANDLE  s_out       = INVALID_HANDLE_VALUE;
+    HANDLE  s_in        = INVALID_HANDLE_VALUE;
+    DWORD   s_outMode   = 0;
+    DWORD   s_inMode    = 0;
+    UINT    s_outCp     = 0;
+
+    int MapVirtualKeyCode(const KEY_EVENT_RECORD& ev)
+    {
+        switch (ev.wVirtualKeyCode)
+        {
+        case VK_RETURN: return KEY_ENTER;
+        case VK_BACK:   return KEY_BACKSPACE;
+        case VK_DELETE: return KEY_DELETE;
+        case VK_LEFT:   return KEY_LEFT;
+        case VK_RIGHT:  return KEY_RIGHT;
+        case VK_UP:     return KEY_UP;
+        case VK_DOWN:   return KEY_DOWN;
+        case VK_HOME:   return KEY_HOME;
+        case VK_END:    return KEY_END;
+        case VK_PRIOR:  return KEY_PAGEUP;
+        case VK_NEXT:   return KEY_PAGEDOWN;
+        case VK_TAB:    return KEY_TAB;
+        default:        break;
+        }
+
+        const wchar_t ch = ev.uChar.UnicodeChar;
+        if (ev.dwControlKeyState & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED))
+        {
+            switch (ch)
+            {
+            case 21: return KEY_KILLLINE;
+            case 23: return KEY_KILLWORD;
+            case 12: return KEY_REDRAW;
+            case 4:  return KEY_EOF;
+            default: break;
+            }
+        }
+
+        return (ch >= 32 || ch == 0) ? int(ch) : KEY_NONE;
+    }
+#else
+    termios s_orig;
+    bool    s_origSaved = false;
+
+    /// Read one more byte of a multi-byte key, waiting up to @p waitMs for it.
+    int NextByte(int waitMs)
+    {
+        pollfd pfd;
+        pfd.fd     = STDIN_FILENO;
+        pfd.events = POLLIN;
+
+        if (poll(&pfd, 1, waitMs) <= 0)
+        {
+            return -1;
+        }
+
+        unsigned char c = 0;
+        return (read(STDIN_FILENO, &c, 1) == 1) ? int(c) : -1;
+    }
+
+    int DecodeEscape()
+    {
+        const int b1 = NextByte(25);
+        if (b1 < 0)
+        {
+            return KEY_NONE;
+        }
+        if (b1 != '[' && b1 != 'O')
+        {
+            return KEY_NONE;
+        }
+
+        const int b2 = NextByte(25);
+        switch (b2)
+        {
+        case 'A': return KEY_UP;
+        case 'B': return KEY_DOWN;
+        case 'C': return KEY_RIGHT;
+        case 'D': return KEY_LEFT;
+        case 'H': return KEY_HOME;
+        case 'F': return KEY_END;
+        default:  break;
+        }
+
+        if (b2 < '0' || b2 > '9')
+        {
+            return KEY_NONE;
+        }
+
+        int value = b2 - '0';
+        for (int b = NextByte(25); b >= 0 && b != '~'; b = NextByte(25))
+        {
+            if (b >= '0' && b <= '9')
+            {
+                value = value * 10 + (b - '0');
+            }
+            else
+            {
+                return KEY_NONE;
+            }
+        }
+
+        switch (value)
+        {
+        case 1:
+        case 7:  return KEY_HOME;
+        case 3:  return KEY_DELETE;
+        case 4:
+        case 8:  return KEY_END;
+        case 5:  return KEY_PAGEUP;
+        case 6:  return KEY_PAGEDOWN;
+        default: return KEY_NONE;
+        }
+    }
+
+    int DecodeUtf8(unsigned char lead)
+    {
+        int extra = 0;
+        int cp    = 0;
+
+        if ((lead & 0xE0) == 0xC0)      { extra = 1; cp = lead & 0x1F; }
+        else if ((lead & 0xF0) == 0xE0) { extra = 2; cp = lead & 0x0F; }
+        else if ((lead & 0xF8) == 0xF0) { extra = 3; cp = lead & 0x07; }
+        else                            { return KEY_NONE; }
+
+        while (extra-- > 0)
+        {
+            const int b = NextByte(25);
+            if (b < 0 || (b & 0xC0) != 0x80)
+            {
+                return KEY_NONE;
+            }
+            cp = (cp << 6) | (b & 0x3F);
+        }
+
+        return cp;
+    }
+#endif
+}
+
+bool Terminal::Active()
+{
+    return s_active;
+}
+
+void Terminal::Write(const std::string& s)
+{
+    Write(s.data(), s.size());
+}
+
+#ifdef _WIN32
+
+bool Terminal::IsInteractive()
+{
+    if (!_isatty(_fileno(stdout)) || !_isatty(_fileno(stdin)))
+    {
+        return false;
+    }
+
+    DWORD mode = 0;
+    return GetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), &mode) != 0;
+}
+
+bool Terminal::Enter()
+{
+    if (s_active || !IsInteractive())
+    {
+        return false;
+    }
+
+    s_out = GetStdHandle(STD_OUTPUT_HANDLE);
+    s_in  = GetStdHandle(STD_INPUT_HANDLE);
+
+    if (!GetConsoleMode(s_out, &s_outMode) || !GetConsoleMode(s_in, &s_inMode))
+    {
+        return false;
+    }
+
+    DWORD wanted = s_outMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING
+                             | ENABLE_PROCESSED_OUTPUT;
+    if (!SetConsoleMode(s_out, wanted))
+    {
+        return false;                                   // pre-1511 console host
+    }
+
+    s_outCp = GetConsoleOutputCP();
+    SetConsoleOutputCP(CP_UTF8);
+
+    // ENABLE_VIRTUAL_TERMINAL_INPUT MUST be off: with it on, the console reports
+    // arrows and page keys as the bytes of an escape sequence spread over several
+    // KEY_EVENTs, which this decoder would take for literal text and type into the
+    // command line. Windows Terminal leaves it on, so clearing it is not optional.
+    // ENABLE_PROCESSED_INPUT stays on so Ctrl+C keeps reaching the console control
+    // handler that drives the existing clean-shutdown path.
+    SetConsoleMode(s_in, (s_inMode & ~(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT
+                                       | ENABLE_VIRTUAL_TERMINAL_INPUT))
+                         | ENABLE_PROCESSED_INPUT | ENABLE_WINDOW_INPUT);
+
+    s_active = true;
+    Write(ENTER_SEQ, sizeof(ENTER_SEQ) - 1);
+    return true;
+}
+
+void Terminal::Leave()
+{
+    if (!s_active)
+    {
+        return;
+    }
+
+    Write(LEAVE_SEQ, sizeof(LEAVE_SEQ) - 1);
+    s_active = false;
+
+    SetConsoleMode(s_out, s_outMode);
+    SetConsoleMode(s_in, s_inMode);
+    if (s_outCp)
+    {
+        SetConsoleOutputCP(s_outCp);
+    }
+}
+
+void Terminal::Size(int& rows, int& cols)
+{
+    CONSOLE_SCREEN_BUFFER_INFO info;
+    if (s_out != INVALID_HANDLE_VALUE && GetConsoleScreenBufferInfo(s_out, &info))
+    {
+        cols = info.srWindow.Right  - info.srWindow.Left + 1;
+        rows = info.srWindow.Bottom - info.srWindow.Top  + 1;
+    }
+    else
+    {
+        rows = 24;
+        cols = 80;
+    }
+}
+
+int Terminal::ReadKey()
+{
+    if (!s_active)
+    {
+        return KEY_NONE;
+    }
+
+    for (;;)
+    {
+        DWORD pending = 0;
+        if (!GetNumberOfConsoleInputEvents(s_in, &pending) || pending == 0)
+        {
+            return KEY_NONE;
+        }
+
+        INPUT_RECORD rec;
+        DWORD read = 0;
+        if (!ReadConsoleInputW(s_in, &rec, 1, &read) || read == 0)
+        {
+            return KEY_NONE;
+        }
+
+        if (rec.EventType == WINDOW_BUFFER_SIZE_EVENT)
+        {
+            return KEY_RESIZE;
+        }
+        if (rec.EventType != KEY_EVENT || !rec.Event.KeyEvent.bKeyDown)
+        {
+            continue;
+        }
+
+        const int key = MapVirtualKeyCode(rec.Event.KeyEvent);
+        if (key != KEY_NONE)
+        {
+            return key;
+        }
+    }
+}
+
+void Terminal::Write(const char* bytes, std::size_t len)
+{
+    if (!len)
+    {
+        return;
+    }
+
+    // WriteFile, not fwrite: stdout is a text-mode CRT stream on Windows and
+    // would rewrite '\n' into "\r\n" inside cursor-positioning sequences.
+    DWORD written = 0;
+    WriteFile(s_out, bytes, DWORD(len), &written, NULL);
+}
+
+#else
+
+bool Terminal::IsInteractive()
+{
+    return isatty(STDOUT_FILENO) != 0 && isatty(STDIN_FILENO) != 0;
+}
+
+bool Terminal::Enter()
+{
+    if (s_active || !IsInteractive())
+    {
+        return false;
+    }
+
+    if (tcgetattr(STDIN_FILENO, &s_orig) != 0)
+    {
+        return false;
+    }
+    s_origSaved = true;
+
+    termios raw = s_orig;
+    raw.c_lflag &= ~(ECHO | ICANON);                    // ISIG kept: Ctrl+C still signals
+    raw.c_cc[VMIN]  = 0;
+    raw.c_cc[VTIME] = 0;
+
+    if (tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw) != 0)
+    {
+        return false;
+    }
+
+    s_active = true;
+    Write(ENTER_SEQ, sizeof(ENTER_SEQ) - 1);
+    return true;
+}
+
+void Terminal::Leave()
+{
+    if (!s_active)
+    {
+        return;
+    }
+
+    Write(LEAVE_SEQ, sizeof(LEAVE_SEQ) - 1);
+    s_active = false;
+
+    if (s_origSaved)
+    {
+        tcsetattr(STDIN_FILENO, TCSAFLUSH, &s_orig);
+    }
+}
+
+void Terminal::Size(int& rows, int& cols)
+{
+    winsize ws;
+    if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == 0 && ws.ws_col > 0)
+    {
+        rows = ws.ws_row;
+        cols = ws.ws_col;
+    }
+    else
+    {
+        rows = 24;
+        cols = 80;
+    }
+}
+
+int Terminal::ReadKey()
+{
+    if (!s_active)
+    {
+        return KEY_NONE;
+    }
+
+    unsigned char c = 0;
+    if (read(STDIN_FILENO, &c, 1) != 1)
+    {
+        return KEY_NONE;
+    }
+
+    switch (c)
+    {
+    case '\r':
+    case '\n': return KEY_ENTER;
+    case 127:
+    case 8:    return KEY_BACKSPACE;
+    case '\t': return KEY_TAB;
+    case 21:   return KEY_KILLLINE;
+    case 23:   return KEY_KILLWORD;
+    case 12:   return KEY_REDRAW;
+    case 4:    return KEY_EOF;
+    case 27:   return DecodeEscape();
+    default:   break;
+    }
+
+    if (c < 32)
+    {
+        return KEY_NONE;
+    }
+
+    return (c < 0x80) ? int(c) : DecodeUtf8(c);
+}
+
+void Terminal::Write(const char* bytes, std::size_t len)
+{
+    while (len > 0)
+    {
+        const ssize_t n = write(STDOUT_FILENO, bytes, len);
+        if (n <= 0)
+        {
+            return;                                     // EPIPE / closed console
+        }
+        bytes += n;
+        len   -= std::size_t(n);
+    }
+}
+
+#endif
+
+}
+}

--- a/src/shared/Console/Terminal.h
+++ b/src/shared/Console/Terminal.h
@@ -1,0 +1,111 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_H_CONSOLE_TERMINAL
+#define MANGOS_H_CONSOLE_TERMINAL
+
+#include <cstddef>
+#include <string>
+
+namespace MaNGOS
+{
+namespace Console
+{
+    /**
+     * @brief Decoded keystroke.
+     *
+     * Values > 0 are Unicode code points. Values < 0 are the named keys below,
+     * so a caller can switch on the negative set and treat everything else as
+     * text.
+     */
+    enum Key
+    {
+        KEY_NONE      = 0,
+        KEY_ENTER     = -1,
+        KEY_BACKSPACE = -2,
+        KEY_DELETE    = -3,
+        KEY_LEFT      = -4,
+        KEY_RIGHT     = -5,
+        KEY_UP        = -6,
+        KEY_DOWN      = -7,
+        KEY_HOME      = -8,
+        KEY_END       = -9,
+        KEY_PAGEUP    = -10,
+        KEY_PAGEDOWN  = -11,
+        KEY_TAB       = -12,
+        KEY_KILLLINE  = -13,
+        KEY_KILLWORD  = -14,
+        KEY_REDRAW    = -15,
+        KEY_EOF       = -16,
+        KEY_RESIZE    = -17
+    };
+
+    /**
+     * @brief Raw terminal control: VT output, unbuffered keystroke input, size.
+     *
+     * The whole platform split of the console UI lives here; everything above
+     * this class is plain VT100/ECMA-48 byte pushing and is identical on
+     * Windows, Linux and the BSDs. Windows 10 1511+ renders those sequences
+     * once ENABLE_VIRTUAL_TERMINAL_PROCESSING is set, which Enter() does.
+     *
+     * Not thread-safe by itself: ConsoleUI owns the instance and serialises
+     * Write() (render thread) against ReadKey() (input thread) by only ever
+     * calling them from their one designated thread.
+     */
+    class Terminal
+    {
+        public:
+            /// True when both stdin and stdout are attached to a real terminal.
+            static bool IsInteractive();
+
+            /**
+             * @brief Switch the terminal into full-screen VT mode.
+             *
+             * Enables VT rendering, turns off line buffering and local echo,
+             * and moves to the alternate screen so Leave() restores whatever
+             * the operator had on screen before. Returns false and changes
+             * nothing when the process is not interactive (service, daemon,
+             * redirected output), which is the caller's cue to stay on the
+             * plain line-oriented logger.
+             */
+            static bool Enter();
+
+            /// Undo Enter(). Safe to call when Enter() failed or never ran.
+            static void Leave();
+
+            static bool Active();
+
+            /// Current window size; falls back to 80x24 if the query fails.
+            static void Size(int& rows, int& cols);
+
+            /// Non-blocking: returns KEY_NONE when nothing is buffered.
+            static int ReadKey();
+
+            static void Write(const char* bytes, std::size_t len);
+            static void Write(const std::string& s);
+    };
+}
+}
+
+#endif

--- a/src/shared/Database/Database.h
+++ b/src/shared/Database/Database.h
@@ -224,13 +224,12 @@ class SqlConnection
          * @brief
          *
          */
-        // Plain, not recursive. Every scope that takes this lock calls only
-        // SqlConnection virtuals (Query/Execute/ExecuteStmt), none of which take
-        // it again; FreePreparedStatements does, but runs solely from the
-        // destructor. A recursive mutex here would only serve to hide a future
-        // mistake -- with a plain one, an accidental reentry deadlocks at once
-        // instead of quietly violating what the lock was protecting.
-        typedef std::mutex LOCK_TYPE;
+        // Recursive, as ACE_Recursive_Thread_Mutex was, and for the reason the
+        // design requires: SqlTransaction::Execute holds this across the whole
+        // BEGIN..COMMIT so nothing interleaves, then runs each queued
+        // SqlOperation, and every one of those takes it again because each must
+        // also work standalone from the delay queue.
+        typedef std::recursive_mutex LOCK_TYPE;
         LOCK_TYPE m_mutex; /**< TODO */
 
         /**

--- a/src/shared/Log/ConsoleLogWriter.cpp
+++ b/src/shared/Log/ConsoleLogWriter.cpp
@@ -33,8 +33,28 @@
 
 #include "Threading/Threading.h"
 #include "ConsoleLogWriter.h"
+#include "Console/ConsoleUI.h"
 
 #include <cstdio>
+
+namespace
+{
+    /// Severity -> full-screen theme. Deliberately not m_colors: the configured
+    /// palette targets a 16-colour console and would clash with the UI's own.
+    MaNGOS::Console::Style StyleFor(LogType type)
+    {
+        switch (type)
+        {
+        case LogDetails: return MaNGOS::Console::STYLE_DETAIL;
+        case LogDebug:   return MaNGOS::Console::STYLE_DEBUG;
+        case LogError:   return MaNGOS::Console::STYLE_ERROR;
+        case LogNormal:
+        default:         return MaNGOS::Console::STYLE_NORMAL;
+        }
+    }
+
+    const int IDLE_RENDER_TICKS = 6;                     // ~30ms between idle repaints
+}
 
 ConsoleLogWriter::ConsoleLogWriter()
     : m_depth(0), m_dropped(0), m_running(true)
@@ -54,9 +74,22 @@ void ConsoleLogWriter::Enqueue(ConsoleLogRecord& rec)
 
 void ConsoleLogWriter::run()
 {
+    int idleTicks = 0;
+
     while (m_running)
     {
-        if (!DrainOnce())
+        const bool didWork = DrainOnce();
+
+        // Sole renderer of the full-screen console: repaint after every drain so
+        // new lines appear at once, and on a slow idle tick so the clock, status
+        // and progress bar keep moving when nothing is being logged.
+        if (didWork || ++idleTicks >= IDLE_RENDER_TICKS)
+        {
+            idleTicks = 0;
+            MaNGOS::Console::ConsoleUI::Instance().Render();
+        }
+
+        if (!didWork)
         {
             MaNGOS::Thread::Sleep(5);
         }
@@ -64,6 +97,7 @@ void ConsoleLogWriter::run()
     // Authoritative final drain: runs on the writer thread while wait()
     // blocks the caller, so any straggler enqueued before Stop() is rendered.
     DrainOnce();
+    MaNGOS::Console::ConsoleUI::Instance().Render();
 }
 
 bool ConsoleLogWriter::DrainOnce()
@@ -86,9 +120,16 @@ bool ConsoleLogWriter::DrainOnce()
         }
         if (n > 0)
         {
-            Log::SetColor(true, RED);
-            fwrite(note, 1, (size_t)n, stdout);
-            Log::ResetColor(true);
+            if (MaNGOS::Console::ConsoleUI::Instance().Active())
+            {
+                MaNGOS::Console::ConsoleUI::Instance().PushLog(note, MaNGOS::Console::STYLE_ERROR);
+            }
+            else
+            {
+                Log::SetColor(true, RED);
+                fwrite(note, 1, (size_t)n, stdout);
+                Log::ResetColor(true);
+            }
         }
         didWork = true;
     }
@@ -105,7 +146,7 @@ bool ConsoleLogWriter::DrainOnce()
     // piped stdout is fully buffered, and flushing here (off the world/map
     // threads) makes output prompt without any producer paying for it. A real
     // console is effectively unbuffered, so this is a cheap no-op there.
-    if (didWork)
+    if (didWork && !MaNGOS::Console::ConsoleUI::Instance().Active())
     {
         fflush(stdout);
     }
@@ -115,6 +156,22 @@ bool ConsoleLogWriter::DrainOnce()
 
 void ConsoleLogWriter::Emit(const ConsoleLogRecord& rec)
 {
+    if (MaNGOS::Console::ConsoleUI::Instance().Active())
+    {
+        // Raw records still reaching here are text (CLI command output, loglevel
+        // notices): the bar is intercepted upstream by the progress sink and the
+        // prompt is suppressed, since the console draws both regions itself.
+        if (rec.isRaw)
+        {
+            MaNGOS::Console::ConsoleUI::Instance().PushRaw(rec.text, MaNGOS::Console::STYLE_NORMAL);
+        }
+        else
+        {
+            MaNGOS::Console::ConsoleUI::Instance().PushLog(rec.text, StyleFor(rec.type));
+        }
+        return;
+    }
+
     FILE* out = rec.toStdout ? stdout : stderr;
     if (rec.isRaw)
     {

--- a/src/shared/Log/Log.cpp
+++ b/src/shared/Log/Log.cpp
@@ -100,16 +100,6 @@ LogFilterData logFilterData[LOG_FILTER_COUNT] =
     { "db_scripts",          "LogFilter_DbScripts",          true  },
 };
 
-enum LogType
-{
-    LogNormal = 0,
-    LogDetails,
-    LogDebug,
-    LogError
-};
-
-const int LogType_count = int(LogError) + 1;
-
 /**
  * @brief Construct the Log singleton
  *
@@ -392,8 +382,10 @@ std::string Log::ConsoleTimePrefix() const
     return std::string(buf);
 }
 
-void Log::ConsoleEmit(bool toStdout, Color color, bool applyColor, const char* fmt, va_list* ap)
+void Log::ConsoleEmit(bool toStdout, LogType type, bool applyColor, const char* fmt, va_list* ap)
 {
+    const Color color = m_colors[type];
+
     // Record text carries NO trailing newline: the newline is emitted after
     // ResetColor (here and in ConsoleLogWriter::Emit) so the line terminator
     // stays OUTSIDE the color span, byte-matching the legacy ordering
@@ -408,6 +400,7 @@ void Log::ConsoleEmit(bool toStdout, Color color, bool applyColor, const char* f
         ConsoleLogRecord rec;
         rec.text = std::move(body);
         rec.color = color;
+        rec.type = type;
         rec.applyColor = applyColor;
         rec.toStdout = toStdout;
         m_consoleBody->Enqueue(rec);
@@ -729,7 +722,7 @@ void Log::outString(const char* str, ...)
     va_list ap;
 
     va_start(ap, str);
-    ConsoleEmit(true, m_colors[LogNormal], m_colored, str, &ap);
+    ConsoleEmit(true, LogNormal, m_colored, str, &ap);
     va_end(ap);
 
     if (logfile)
@@ -754,7 +747,7 @@ void Log::outError(const char* err, ...)
     va_list ap;
 
     va_start(ap, err);
-    ConsoleEmit(false, m_colors[LogError], m_colored, err, &ap);
+    ConsoleEmit(false, LogError, m_colored, err, &ap);
     va_end(ap);
 
     if (logfile)
@@ -800,7 +793,7 @@ void Log::outErrorDb(const char* err, ...)
     va_list ap;
 
     va_start(ap, err);
-    ConsoleEmit(false, m_colors[LogError], m_colored, err, &ap);
+    ConsoleEmit(false, LogError, m_colored, err, &ap);
     va_end(ap);
 
     if (logfile)
@@ -865,7 +858,7 @@ void Log::outErrorEluna(const char* err, ...)
     va_list ap;
 
     va_start(ap, err);
-    ConsoleEmit(false, m_colors[LogError], m_colored, err, &ap);
+    ConsoleEmit(false, LogError, m_colored, err, &ap);
     va_end(ap);
 
     if (logfile)
@@ -928,7 +921,7 @@ void Log::outErrorEventAI(const char* err, ...)
     va_list ap;
 
     va_start(ap, err);
-    ConsoleEmit(false, m_colors[LogError], m_colored, err, &ap);
+    ConsoleEmit(false, LogError, m_colored, err, &ap);
     va_end(ap);
 
     if (logfile)
@@ -969,7 +962,7 @@ void Log::outBasic(const char* str, ...)
     {
         va_list ap;
         va_start(ap, str);
-        ConsoleEmit(true, m_colors[LogDetails], m_colored, str, &ap);
+        ConsoleEmit(true, LogDetails, m_colored, str, &ap);
         va_end(ap);
     }
 
@@ -996,7 +989,7 @@ void Log::outDetail(const char* str, ...)
     {
         va_list ap;
         va_start(ap, str);
-        ConsoleEmit(true, m_colors[LogDetails], m_colored, str, &ap);
+        ConsoleEmit(true, LogDetails, m_colored, str, &ap);
         va_end(ap);
     }
 
@@ -1025,7 +1018,7 @@ void Log::outDebug(const char* str, ...)
     {
         va_list ap;
         va_start(ap, str);
-        ConsoleEmit(true, m_colors[LogDebug], m_colored, str, &ap);
+        ConsoleEmit(true, LogDebug, m_colored, str, &ap);
         va_end(ap);
     }
 
@@ -1054,7 +1047,7 @@ void Log::outCommand(uint32 account, const char* str, ...)
     {
         va_list ap;
         va_start(ap, str);
-        ConsoleEmit(true, m_colors[LogDetails], m_colored, str, &ap);
+        ConsoleEmit(true, LogDetails, m_colored, str, &ap);
         va_end(ap);
     }
 
@@ -1120,7 +1113,7 @@ void Log::outWarden(const char* str, ...)
         va_list ap;
 
         va_start(ap, str);
-        ConsoleEmit(true, m_colors[LogNormal], m_colored, str, &ap);
+        ConsoleEmit(true, LogNormal, m_colored, str, &ap);
         va_end(ap);
     }
 
@@ -1197,7 +1190,7 @@ void Log::outErrorScriptLib(const char* err, ...)
     va_list ap;
 
     va_start(ap, err);
-    ConsoleEmit(false, m_colors[LogError], m_colored, err, &ap);
+    ConsoleEmit(false, LogError, m_colored, err, &ap);
     va_end(ap);
 
     if (logfile)

--- a/src/shared/Log/Log.h
+++ b/src/shared/Log/Log.h
@@ -133,6 +133,19 @@ enum Color
 const int Color_count = int(WHITE) + 1; /**< Total number of available colors **/
 
 /**
+ * @brief Severity of a line, and the index into the configured colour table
+ */
+enum LogType
+{
+    LogNormal = 0,
+    LogDetails,
+    LogDebug,
+    LogError
+};
+
+const int LogType_count = int(LogError) + 1; /**< Size of the colour table */
+
+/**
  * @brief One formatted console line handed to the off-thread writer
  *
  * Producers format text (time prefix + body, WITHOUT the trailing newline) and
@@ -143,11 +156,12 @@ struct ConsoleLogRecord
 {
     std::string text; /**< Formatted line WITHOUT the trailing newline; the writer appends '\n' after ResetColor */
     Color color; /**< Color to apply when applyColor is set */
+    LogType type; /**< Severity, kept alongside the colour so the full-screen console can theme independently of the configured palette */
     bool applyColor; /**< Whether to wrap the write in SetColor/ResetColor */
     bool toStdout; /**< true => stdout, false => stderr */
     bool isRaw; /**< Raw passthrough: write text verbatim with NO color and NO appended newline (used for progress-bar redraws, which carry their own '\r'/'\n' and must not be reformatted) */
 
-    ConsoleLogRecord() : color(WHITE), applyColor(false), toStdout(true), isRaw(false) {}
+    ConsoleLogRecord() : color(WHITE), type(LogNormal), applyColor(false), toStdout(true), isRaw(false) {}
 };
 
 /**
@@ -514,12 +528,12 @@ class Log : public MaNGOS::Singleton<Log>
          *        color and whether color applies.
          *
          * @param toStdout true => stdout, false => stderr
-         * @param color
+         * @param type severity; selects the colour from m_colors
          * @param applyColor
          * @param fmt
          * @param ap
          */
-        void ConsoleEmit(bool toStdout, Color color, bool applyColor, const char* fmt, va_list* ap);
+        void ConsoleEmit(bool toStdout, LogType type, bool applyColor, const char* fmt, va_list* ap);
 
         /// Emit a blank console line (time prefix + newline) via the writer / fallback.
         void ConsoleEmitBlank(bool toStdout);

--- a/src/shared/Utilities/ProgressBar.cpp
+++ b/src/shared/Utilities/ProgressBar.cpp
@@ -72,10 +72,28 @@ void BarGoLink::DefaultSink(char const* bytes, size_t len)
 }
 
 BarGoLink::ConsoleSink BarGoLink::m_sink = &BarGoLink::DefaultSink;
+BarGoLink::ProgressSink BarGoLink::m_progressSink = NULL;
 
 void BarGoLink::SetConsoleSink(ConsoleSink sink)
 {
     m_sink = sink ? sink : &BarGoLink::DefaultSink;
+}
+
+void BarGoLink::SetProgressSink(ProgressSink sink)
+{
+    m_progressSink = sink;
+}
+
+void BarGoLink::emit(int percent, const std::string& bytes)
+{
+    if (m_progressSink)
+    {
+        m_progressSink(percent);
+    }
+    else
+    {
+        m_sink(bytes.data(), bytes.size());
+    }
 }
 
 /**
@@ -105,8 +123,7 @@ BarGoLink::~BarGoLink()
         return;
     }
 
-    std::string const bar = ProgressBarRender::buildEnd();
-    m_sink(bar.data(), bar.size());
+    emit(-1, ProgressBarRender::buildEnd());
 }
 
 /**
@@ -130,8 +147,7 @@ void BarGoLink::init(int row_count)
         return;
     }
 
-    std::string const bar = ProgressBarRender::buildInit(indic_len);
-    m_sink(bar.data(), bar.size());
+    emit(0, ProgressBarRender::buildInit(indic_len));
 }
 
 /**
@@ -160,8 +176,7 @@ void BarGoLink::step()
     int n = rec_no * indic_len / num_rec;
     if (n != rec_pos)
     {
-        std::string const bar = ProgressBarRender::buildStep(n, indic_len);
-        m_sink(bar.data(), bar.size());
+        emit(n * 100 / indic_len, ProgressBarRender::buildStep(n, indic_len));
         rec_pos = n;
     }
 }

--- a/src/shared/Utilities/ProgressBar.h
+++ b/src/shared/Utilities/ProgressBar.h
@@ -28,6 +28,7 @@
 #include "Platform/Define.h"
 
 #include <cstddef>
+#include <string>
 
 /**
  * @brief
@@ -83,6 +84,21 @@ class BarGoLink
          * @param sink
          */
         static void SetConsoleSink(ConsoleSink sink);
+
+        /**
+         * @brief Progress sink for a console that draws the bar itself.
+         *
+         * Reports the completion percentage rather than the bytes of a redraw:
+         * 0 when a bar starts, its current value as it advances, and -1 when it
+         * is done. A full-screen console owns a progress region and needs the
+         * number, not a '\r'-terminated repaint. Installing one suppresses the
+         * byte sink, since the two would draw the same bar twice.
+         */
+        typedef void (*ProgressSink)(int percent);
+
+        /// Install the progress sink. Passing NULL restores byte-sink drawing.
+        static void SetProgressSink(ProgressSink sink);
+
     private:
         /**
          * @brief
@@ -94,7 +110,11 @@ class BarGoLink
         /// Default synchronous sink: fwrite(stdout)+fflush (legacy behaviour).
         static void DefaultSink(char const* bytes, size_t len);
 
+        /// Route one visual update to whichever sink is installed.
+        void emit(int percent, const std::string& bytes);
+
         static ConsoleSink m_sink; /**< active console sink for built bar redraws */
+        static ProgressSink m_progressSink; /**< when set, takes over from m_sink */
         static bool m_showOutput; /**< not recommended change with existed active bar */
 
         int rec_no; /**< TODO */


### PR DESCRIPTION
Removing ACE turned SqlConnection's ACE_Recursive_Thread_Mutex into a plain std::mutex, on the stated grounds that no scope taking it reenters. That is not true of the transaction path:

    SqlTransaction::Execute(conn)  { LOCK_DB_CONN(conn); ... pStmt->Execute(conn); }
    SqlPlainRequest::Execute(conn) { LOCK_DB_CONN(conn); ... }

The transaction holds the connection across BEGIN..COMMIT so nothing interleaves, then runs each queued operation -- and each takes the same lock again, because each must also work standalone from the delay queue.

So every transaction carrying at least one statement self-deadlocks on commit, on the delay thread. libc++ detects it and throws std::system_error, which leaves the thread with no handler and aborts the process; glibc does not detect it and the delay thread simply stops, taking every later write with it.

Found by a stress test committing transactions from several threads, and confirmed under lldb:

    std::mutex::lock() -> __throw_system_error
    SqlPlainRequest::Execute -> SqlTransaction::Execute
    -> SqlDelayThread::ProcessRequests

The other four recursive mutexes ACE provided were checked at the same time. MapManager was converted correctly, by splitting FindMap into a locking wrapper and an unlocked body; BattleGroundQueue's guards had all been commented out long before, so its mutex was already a dead member.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/241)
<!-- Reviewable:end -->
