### PR TITLE
Decouple network transport from world session policy

### DIFF
--- a/.github/workflows/core_linux_build.yml
+++ b/.github/workflows/core_linux_build.yml
@@ -68,6 +68,7 @@ jobs:
           -DBUILD_TOOLS=1
           -DBUILD_MANGOSD=1
           -DBUILD_REALMD=1
+          -DWITH_TESTS=1
           -DSOAP=1
           -DSCRIPT_LIB_ELUNA=1
           -DSCRIPT_LIB_SD3=1
@@ -76,6 +77,9 @@ jobs:
 
       - name: Build
         run: cmake --build "$BUILD_DIR" --parallel
+
+      - name: Test
+        run: ctest --test-dir "$BUILD_DIR" --output-on-failure
 
       - name: Install
         run: cmake --install "$BUILD_DIR"

--- a/.github/workflows/core_windows_build.yml
+++ b/.github/workflows/core_windows_build.yml
@@ -13,6 +13,10 @@ concurrency:
   group: windows-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  OPENSSL_VERSION: 3.6.3
+  OPENSSL_SHA512: 120A2E9A3E8B961484CB94D52F85D48DC2C8AF777B5B3B9E26BF49B4408797281F7C0FB2D543FD7796B3C3232ADFAA0F675E7122C0E5C4225B3B02E767197AC6
+
 jobs:
   build:
     runs-on: windows-2022
@@ -29,28 +33,67 @@ jobs:
           submodules: recursive
           fetch-depth: 1
 
+      # Bump the -vN suffix to force a re-install of OpenSSL.
       - name: Cache OpenSSL
         id: cache-openssl
         uses: actions/cache@v4
         with:
-          path: |
-            C:\Program Files\OpenSSL
-            C:\Program Files\OpenSSL-Win64
-          key: ${{ runner.os }}-openssl-3
+          path: C:\Program Files\OpenSSL-Win64
+          key: ${{ runner.os }}-openssl-${{ env.OPENSSL_VERSION }}-v1
 
-      - name: Install OpenSSL
+      - name: Install full OpenSSL (developer)
         if: steps.cache-openssl.outputs.cache-hit != 'true'
-        run: choco upgrade openssl -y --no-progress
+        shell: powershell
+        run: |
+          $versionSlug = $env:OPENSSL_VERSION.Replace('.', '_')
+          $installer = Join-Path $env:RUNNER_TEMP "Win64OpenSSL-$versionSlug.exe"
+          $url = "https://slproweb.com/download/Win64OpenSSL-$versionSlug.exe"
 
-      - name: Locate OpenSSL
+          Write-Host "Downloading OpenSSL $env:OPENSSL_VERSION for development..."
+          curl.exe --fail --location --retry 3 --output $installer $url
+          if ($LASTEXITCODE -ne 0) {
+            throw "OpenSSL download failed with exit code $LASTEXITCODE"
+          }
+
+          $actualHash = (Get-FileHash -Algorithm SHA512 $installer).Hash
+          if ($actualHash -ne $env:OPENSSL_SHA512) {
+            throw "OpenSSL installer checksum mismatch: $actualHash"
+          }
+
+          $installArgs = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /DIR="C:\Program Files\OpenSSL-Win64"'
+          $process = Start-Process -FilePath $installer -ArgumentList $installArgs -Wait -PassThru
+          if ($process.ExitCode -ne 0) {
+            throw "OpenSSL installer failed with exit code $($process.ExitCode)"
+          }
+
+      - name: Verify OpenSSL major version
+        shell: powershell
+        run: |
+          $openssl = "C:\Program Files\OpenSSL-Win64\bin\openssl.exe"
+          if (-not (Test-Path $openssl)) {
+            throw "OpenSSL executable not found at $openssl"
+          }
+
+          $version = & $openssl version
+          Write-Host "Installed OpenSSL version: $version"
+          if ($version -notmatch '^OpenSSL 3\.') {
+            throw "Windows CI requires OpenSSL 3.x, found: $version"
+          }
+
+      - name: Configure OpenSSL environment
         shell: bash
         run: |
-          for root in "C:/Program Files/OpenSSL" "C:/Program Files/OpenSSL-Win64"; do
-            if [ -d "$root/lib/VC" ]; then
-              echo "OPENSSL_ROOT_DIR=$root" >> $GITHUB_ENV
-              break
-            fi
-          done
+          root="C:/Program Files/OpenSSL-Win64"
+          if [ -d "$root/lib/VC" ]; then
+            echo "OPENSSL_ROOT_DIR=$root" >> "$GITHUB_ENV"
+            echo "OPENSSL_INCLUDE_DIR=$root/include" >> "$GITHUB_ENV"
+            echo "OPENSSL_CRYPTO_LIBRARY=$root/lib/VC/libcrypto64MT.lib" >> "$GITHUB_ENV"
+            echo "OPENSSL_SSL_LIBRARY=$root/lib/VC/libssl64MT.lib" >> "$GITHUB_ENV"
+            echo "$root/bin" >> "$GITHUB_PATH"
+          else
+            echo "::error::OpenSSL developer libraries not found"
+            exit 1
+          fi
 
       - name: Setup MSVC environment
         uses: ilammy/msvc-dev-cmd@v1
@@ -72,9 +115,11 @@ jobs:
           -DCMAKE_INSTALL_PREFIX="$BUILD_DIR/install"
           -DCMAKE_C_COMPILER_LAUNCHER=sccache
           -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          -DOPENSSL_ROOT_DIR="$OPENSSL_ROOT_DIR"
           -DBUILD_TOOLS=1
           -DBUILD_MANGOSD=1
           -DBUILD_REALMD=1
+          -DWITH_TESTS=1
           -DSOAP=1
           -DSCRIPT_LIB_ELUNA=1
           -DSCRIPT_LIB_SD3=1
@@ -84,6 +129,10 @@ jobs:
       - name: Build
         shell: bash
         run: cmake --build "$BUILD_DIR" --parallel
+
+      - name: Test
+        shell: bash
+        run: ctest --test-dir "$BUILD_DIR" --output-on-failure
 
       - name: Verify the working tree is clean
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,13 @@ endif()
 
 find_package(Threads REQUIRED)
 find_package(OpenSSL 3.0 REQUIRED)
+
+# OpenSSL 4.x support is intentionally deferred until the OpenSSL 4.2 LTS migration.
+if(OPENSSL_VERSION VERSION_GREATER_EQUAL "4.0.0")
+  message(FATAL_ERROR
+    "Unsupported OpenSSL ${OPENSSL_VERSION}: MaNGOS currently requires >=3.0.0 and <4.0.0")
+endif()
+
 find_package(MySQL REQUIRED)
 
 # =============================================================================

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,17 +49,6 @@ endif()
 # Build the mangos realm authentication server
 if(BUILD_REALMD)
     add_subdirectory(realmd)
-
-    # Upstream realmd passes the *file* ${CMAKE_CURRENT_BINARY_DIR}/VersionInfo.h
-    # to target_include_directories, where a directory belongs. The Visual Studio
-    # generator happens to hand the target's own binary directory to the resource
-    # compiler anyway, so it built; Ninja does not, and VersionInfo.rc then fails
-    # to find the header it includes. The submodule is not modified here, so the
-    # directory is added from outside. Remove once upstream fixes the path.
-    if(WIN32)
-        target_include_directories(realmd
-            PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/realmd")
-    endif()
 endif()
 
 # The client-data parsers are configured unconditionally: the unit tests link them

--- a/src/game/Server/OpcodeTable.cpp
+++ b/src/game/Server/OpcodeTable.cpp
@@ -559,7 +559,7 @@ void InitializeOpcodes()
     OPCODE(SMSG_START_MIRROR_TIMER,                        STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     OPCODE(SMSG_PAUSE_MIRROR_TIMER,                        STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     OPCODE(SMSG_STOP_MIRROR_TIMER,                         STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
-    OPCODE(CMSG_PING,                                      STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_EarlyProccess);
+    OPCODE(CMSG_PING,                                      STATUS_AUTHED,   PROCESS_THREADUNSAFE, &WorldSession::HandlePingOpcode);
     OPCODE(SMSG_PONG,                                      STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     OPCODE(SMSG_CLEAR_COOLDOWN,                            STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     OPCODE(SMSG_GAMEOBJECT_PAGETEXT,                       STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
@@ -1114,7 +1114,7 @@ void InitializeOpcodes()
     OPCODE(SMSG_SPELL_CHANCE_RESIST_PUSHBACK,              STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     OPCODE(CMSG_IGNORE_DIMINISHING_RETURNS_CHEAT,          STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL);
     OPCODE(SMSG_IGNORE_DIMINISHING_RETURNS_CHEAT,          STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
-    OPCODE(CMSG_KEEP_ALIVE,                                STATUS_NEVER,    PROCESS_THREADUNSAFE, &WorldSession::Handle_EarlyProccess);
+    OPCODE(CMSG_KEEP_ALIVE,                                STATUS_AUTHED,   PROCESS_THREADUNSAFE, &WorldSession::HandleKeepAliveOpcode);
     OPCODE(SMSG_RAID_READY_CHECK_ERROR,                    STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     OPCODE(CMSG_OPT_OUT_OF_LOOT,                           STATUS_AUTHED,   PROCESS_THREADUNSAFE, &WorldSession::HandleOptOutOfLootOpcode);
     OPCODE(MSG_QUERY_GUILD_BANK_TEXT,                      STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleQueryGuildBankTabText);

--- a/src/game/Server/SessionMailbox.cpp
+++ b/src/game/Server/SessionMailbox.cpp
@@ -1,0 +1,73 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "SessionMailbox.h"
+
+SessionMailbox::~SessionMailbox()
+{
+    Close();
+}
+
+bool SessionMailbox::Enqueue(std::unique_ptr<WorldPacket> packet)
+{
+    if (!packet)
+        return false;
+
+    std::lock_guard<std::mutex> guard(m_stateLock);
+    if (m_closed)
+        return false;
+
+    WorldPacket* accepted = packet.get();
+    m_packets.add(accepted);
+    packet.release();
+    return true;
+}
+
+bool SessionMailbox::Next(WorldPacket*& packet)
+{
+    std::lock_guard<std::mutex> guard(m_stateLock);
+    if (m_closed)
+        return false;
+    return m_packets.next(packet);
+}
+
+void SessionMailbox::Close()
+{
+    {
+        std::lock_guard<std::mutex> guard(m_stateLock);
+        if (m_closed)
+            return;
+        m_closed = true;
+    }
+
+    WorldPacket* packet = nullptr;
+    while (m_packets.next(packet))
+        delete packet;
+}
+
+bool SessionMailbox::IsClosed() const
+{
+    std::lock_guard<std::mutex> guard(m_stateLock);
+    return m_closed;
+}

--- a/src/game/Server/SessionMailbox.cpp
+++ b/src/game/Server/SessionMailbox.cpp
@@ -40,7 +40,7 @@ bool SessionMailbox::Enqueue(std::unique_ptr<WorldPacket> packet)
 
     WorldPacket* accepted = packet.get();
     m_packets.add(accepted);
-    packet.release();
+    (void)packet.release();
     return true;
 }
 

--- a/src/game/Server/SessionMailbox.h
+++ b/src/game/Server/SessionMailbox.h
@@ -1,0 +1,61 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_H_SESSIONMAILBOX
+#define MANGOS_H_SESSIONMAILBOX
+
+#include "LockedQueue/LockedQueue.h"
+#include "Utilities/WorldPacket.h"
+
+#include <memory>
+#include <mutex>
+
+class SessionMailbox
+{
+    public:
+        SessionMailbox() = default;
+        ~SessionMailbox();
+
+        bool Enqueue(std::unique_ptr<WorldPacket> packet);
+        bool Next(WorldPacket*& packet);
+
+        template<class Checker>
+        bool Next(WorldPacket*& packet, Checker& checker)
+        {
+            std::lock_guard<std::mutex> guard(m_stateLock);
+            if (m_closed)
+                return false;
+            return m_packets.next(packet, checker);
+        }
+
+        void Close();
+        bool IsClosed() const;
+
+    private:
+        mutable std::mutex m_stateLock;
+        bool m_closed = false;
+        MaNGOS::LockedQueue<WorldPacket*> m_packets;
+};
+
+#endif

--- a/src/game/Server/SessionProtocolPolicy.h
+++ b/src/game/Server/SessionProtocolPolicy.h
@@ -1,0 +1,72 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_H_SESSIONPROTOCOLPOLICY
+#define MANGOS_H_SESSIONPROTOCOLPOLICY
+
+#include "Opcodes.h"
+#include "Platform/Define.h"
+
+#include <chrono>
+
+class SessionPingTracker
+{
+    public:
+        using Clock = std::chrono::steady_clock;
+
+        uint32 Record(Clock::time_point now)
+        {
+            if (!m_hadPing)
+            {
+                m_hadPing = true;
+                m_lastPing = now;
+                return 0;
+            }
+
+            bool fast = now - m_lastPing < std::chrono::seconds(27);
+            m_lastPing = now;
+            if (fast)
+                return ++m_fastRun;
+
+            m_fastRun = 0;
+            return 0;
+        }
+
+        bool ShouldKick(uint32 maximum, bool ordinaryPlayer) const
+        {
+            return maximum != 0 && m_fastRun > maximum && ordinaryPlayer;
+        }
+
+    private:
+        Clock::time_point m_lastPing{};
+        bool m_hadPing = false;
+        uint32 m_fastRun = 0;
+};
+
+inline bool IsAllowedWhileLoginQueued(uint32 opcode)
+{
+    return opcode == CMSG_PING || opcode == CMSG_KEEP_ALIVE;
+}
+
+#endif

--- a/src/game/Server/WorldGateway.cpp
+++ b/src/game/Server/WorldGateway.cpp
@@ -303,7 +303,7 @@ proto::SessionId WorldGateway::Attach(const proto::AuthRequest& request,
         Detach(id);
         throw;
     }
-    session.release();
+    (void)session.release();
 
     return id;
 }

--- a/src/game/Server/WorldGateway.cpp
+++ b/src/game/Server/WorldGateway.cpp
@@ -293,17 +293,17 @@ proto::SessionId WorldGateway::Attach(const proto::AuthRequest& request,
     // out encrypted -- which is the one ordering constraint across this seam.
     // AddSession also answers the addon block, via SendAddonsInfo() over the
     // list ReadAddonsInfo() just parsed -- so nothing more is owed here.
-    WorldSession* published = session.get();
+    WorldSession* published = session.release();
     try
     {
         sWorld.AddSession(published);
     }
     catch (...)
     {
+        session.reset(published);
         Detach(id);
         throw;
     }
-    (void)session.release();
 
     return id;
 }
@@ -340,4 +340,8 @@ void WorldGateway::Detach(proto::SessionId session)
     }
 
     mailbox->Close();
+
+    // The transport marks the shared client link closed before calling Detach.
+    // WorldSession::Update observes that state on the world thread, logs the
+    // player out, and returns false so World::UpdateSessions reaps the session.
 }

--- a/src/game/Server/WorldGateway.cpp
+++ b/src/game/Server/WorldGateway.cpp
@@ -34,6 +34,7 @@
 #include "Database/DatabaseEnv.h"
 #include "Log/Log.h"
 #include "SharedDefines.h"
+#include "SessionMailbox.h"
 #include "World.h"
 #include "WorldSession.h"
 
@@ -227,8 +228,9 @@ proto::SessionId WorldGateway::Attach(const proto::AuthRequest& request,
 {
     EnsureDbThreadRegistered();
 
-    AccountRow* row = static_cast<AccountRow*>(context.get());
-    if (row == nullptr)
+    std::shared_ptr<AccountRow> row =
+        std::dynamic_pointer_cast<AccountRow>(context);
+    if (!link || !row)
     {
         return proto::INVALID_SESSION_ID;
     }
@@ -240,9 +242,12 @@ proto::SessionId WorldGateway::Attach(const proto::AuthRequest& request,
         updAccount, "UPDATE `account` SET `last_ip` = ? WHERE `username` = ?");
     stmt.PExecute(request.peerAddress.c_str(), request.account.c_str());
 
-    WorldSession* session = new WorldSession(row->id, link, row->security,
-                                             row->expansion, row->muteTime,
-                                             row->locale, row->sessionKey);
+    std::shared_ptr<SessionMailbox> mailbox =
+        std::make_shared<SessionMailbox>();
+    std::unique_ptr<WorldSession> session =
+        std::make_unique<WorldSession>(
+            row->id, link, mailbox, row->security, row->expansion,
+            row->muteTime, row->locale, row->sessionKey);
 
     session->LoadGlobalAccountData();
     session->LoadTutorialsData();
@@ -263,11 +268,24 @@ proto::SessionId WorldGateway::Attach(const proto::AuthRequest& request,
         session->InitWarden(uint16(request.build), &row->sessionKey, row->os);
     }
 
+    if (link->IsClosed())
+    {
+        return proto::INVALID_SESSION_ID;
+    }
+
     proto::SessionId id;
     {
         std::lock_guard<std::mutex> lock(m_lock);
-        id = m_nextId++;
-        m_sessions[id] = session;
+        do
+        {
+            id = m_nextId++;
+            if (id == proto::INVALID_SESSION_ID)
+            {
+                id = m_nextId++;
+            }
+        }
+        while (m_routes.find(id) != m_routes.end());
+        m_routes.emplace(id, mailbox);
     }
 
     // AddSession answers the client itself, with either AUTH_OK or a queue
@@ -275,84 +293,51 @@ proto::SessionId WorldGateway::Attach(const proto::AuthRequest& request,
     // out encrypted -- which is the one ordering constraint across this seam.
     // AddSession also answers the addon block, via SendAddonsInfo() over the
     // list ReadAddonsInfo() just parsed -- so nothing more is owed here.
-    sWorld.AddSession(session);
+    WorldSession* published = session.get();
+    try
+    {
+        sWorld.AddSession(published);
+    }
+    catch (...)
+    {
+        Detach(id);
+        throw;
+    }
+    session.release();
 
     return id;
 }
 
 void WorldGateway::Deliver(proto::SessionId session, WorldPacket&& packet)
 {
-    std::lock_guard<std::mutex> lock(m_lock);
-
-    if (WorldSession* target = Find(session))
+    std::shared_ptr<SessionMailbox> mailbox;
     {
-        // QueuePacket takes ownership; the world thread drains and frees it.
-        target->QueuePacket(new WorldPacket(std::move(packet)));
-    }
-}
-
-bool WorldGateway::OnPing(proto::SessionId session, uint32 latency,
-                          uint32 fastPingRun)
-{
-    std::lock_guard<std::mutex> lock(m_lock);
-
-    WorldSession* target = Find(session);
-
-    // A ping before authenticating is not something a real client does.
-    if (target == NULL)
-    {
-        return false;
+        std::lock_guard<std::mutex> lock(m_lock);
+        auto route = m_routes.find(session);
+        if (route == m_routes.end())
+        {
+            return;
+        }
+        mailbox = route->second;
     }
 
-    target->SetLatency(latency);
-
-    // Overspeed policy. A configured maximum of zero disables the check entirely,
-    // which is the historical meaning of the option.
-    const uint32 maxCount = sWorld.getConfig(CONFIG_UINT32_MAX_OVERSPEED_PINGS);
-    if (maxCount == 0 || fastPingRun <= maxCount)
-    {
-        return true;
-    }
-
-    // Staff accounts are exempt: the check exists to catch clients hammering the
-    // server, and a GM tool legitimately does.
-    if (target->GetSecurity() != SEC_PLAYER)
-    {
-        return true;
-    }
-
-    sLog.outError("WorldGateway: kicking account %u for overspeed pings (%u in a row)",
-                  target->GetAccountId(), fastPingRun);
-    return false;
+    mailbox->Enqueue(std::make_unique<WorldPacket>(std::move(packet)));
 }
 
 void WorldGateway::Detach(proto::SessionId session)
 {
-    WorldSession* target = NULL;
+    std::shared_ptr<SessionMailbox> mailbox;
     {
         std::lock_guard<std::mutex> lock(m_lock);
 
-        auto it = m_sessions.find(session);
-        if (it == m_sessions.end())
+        auto route = m_routes.find(session);
+        if (route == m_routes.end())
         {
             return;
         }
-        target = it->second;
-        m_sessions.erase(it);
+        mailbox = route->second;
+        m_routes.erase(route);
     }
 
-    // The session is not deleted here. It still holds a player that has to be
-    // saved and taken off the map, which only the world thread may do; the world
-    // reaps it on a later tick. The link it holds is already disarmed, so any
-    // packet it tries to send on the way out is discarded rather than crashing.
-    if (target != NULL)
-    {
-        target->KickPlayer();
-    }
-}
-
-WorldSession* WorldGateway::Find(proto::SessionId session) const
-{
-    auto it = m_sessions.find(session);
-    return it == m_sessions.end() ? NULL : it->second;
+    mailbox->Close();
 }

--- a/src/game/Server/WorldGateway.h
+++ b/src/game/Server/WorldGateway.h
@@ -31,7 +31,7 @@
 #include <mutex>
 #include <unordered_map>
 
-class WorldSession;
+class SessionMailbox;
 
 /**
  * @brief The world's side of the protocol seam.
@@ -63,15 +63,9 @@ class WorldGateway : public proto::IWorldGateway
 
         void Deliver(proto::SessionId session, WorldPacket&& packet) override;
 
-        bool OnPing(proto::SessionId session, uint32 latency,
-                    uint32 fastPingRun) override;
-
         void Detach(proto::SessionId session) override;
 
     private:
-
-        /// Resolve a handle to a live session, or NULL. Caller must hold m_lock.
-        WorldSession* Find(proto::SessionId session) const;
 
         mutable std::mutex m_lock;
 
@@ -80,7 +74,7 @@ class WorldGateway : public proto::IWorldGateway
         /// session of a player who has since logged back in.
         proto::SessionId m_nextId;
 
-        std::unordered_map<proto::SessionId, WorldSession*> m_sessions;
+        std::unordered_map<proto::SessionId, std::shared_ptr<SessionMailbox>> m_routes;
 };
 
 #endif

--- a/src/game/Server/WorldSession.cpp
+++ b/src/game/Server/WorldSession.cpp
@@ -200,7 +200,10 @@ WorldSession::~WorldSession()
         m_link.reset();
     }
 
-    delete _warden;
+    if (_warden)
+    {
+        delete _warden;
+    }
 }
 
 /**

--- a/src/game/Server/WorldSession.cpp
+++ b/src/game/Server/WorldSession.cpp
@@ -691,16 +691,17 @@ void WorldSession::HandlePingOpcode(WorldPacket& recvPacket)
     recvPacket >> ping;
     recvPacket >> latency;
 
-    m_pingTracker.Record(SessionPingTracker::Clock::now());
+    uint32 fastPingRun =
+        m_pingTracker.Record(SessionPingTracker::Clock::now());
     uint32 maximum =
         sWorld.getConfig(CONFIG_UINT32_MAX_OVERSPEED_PINGS);
     if (m_pingTracker.ShouldKick(
             maximum, GetSecurity() == SEC_PLAYER))
     {
         sLog.outError(
-            "WorldSession::HandlePingOpcode: Player kicked for "
-            "overspeeded pings address = %s",
-            GetRemoteAddress().c_str());
+            "WorldSession::HandlePingOpcode: account %u kicked for "
+            "overspeeded pings (%u in a row), address = %s",
+            GetAccountId(), fastPingRun, GetRemoteAddress().c_str());
         KickPlayer();
         return;
     }

--- a/src/game/Server/WorldSession.cpp
+++ b/src/game/Server/WorldSession.cpp
@@ -68,6 +68,7 @@
 #include "OpcodeTable.h"
 #include "WorldPacket.h"
 #include "WorldSession.h"
+#include "SessionMailbox.h"
 #include "Player.h"
 #include "ObjectMgr.h"
 #include "Group.h"
@@ -162,9 +163,12 @@ bool WorldSessionFilter::Process(WorldPacket* packet)
 
 /// WorldSession constructor
 WorldSession::WorldSession(uint32 id, std::shared_ptr<proto::IClientLink> link,
+                           std::shared_ptr<SessionMailbox> mailbox,
                            AccountTypes sec, uint8 expansion, time_t mute_time,
                            LocaleConstant locale, const BigNumber& sessionKey) :
-    m_muteTime(mute_time), _player(nullptr), m_link(std::move(link)), m_sessionKey(sessionKey),
+    m_muteTime(mute_time), _player(nullptr), m_link(std::move(link)),
+    m_mailbox(mailbox ? std::move(mailbox) : std::make_shared<SessionMailbox>()),
+    m_sessionKey(sessionKey),
     _security(sec), _accountId(id), _warden(nullptr), m_expansion(expansion), _logoutTime(0),
     m_inQueue(false), m_playerLoading(false), m_playerLogout(false), m_playerRecentlyLogout(false), m_playerSave(false),
     m_sessionDbcLocale(sWorld.GetAvailableDbcLocale(locale)), m_sessionDbLocaleIndex(sObjectMgr.GetIndexForLocale(locale)),
@@ -179,6 +183,8 @@ WorldSession::WorldSession(uint32 id, std::shared_ptr<proto::IClientLink> link,
 /// WorldSession destructor
 WorldSession::~WorldSession()
 {
+    m_mailbox->Close();
+
     ///- unload player if not unloaded
     if (_player)
     {
@@ -194,18 +200,7 @@ WorldSession::~WorldSession()
         m_link.reset();
     }
 
-    // Warden
-    if (_warden)
-    {
-        delete _warden;
-    }
-
-    ///- empty incoming packet queue
-    WorldPacket* packet = NULL;
-    while (_recvQueue.next(packet))
-    {
-        delete packet;
-    }
+    delete _warden;
 }
 
 /**
@@ -285,7 +280,7 @@ void WorldSession::SendPacket(WorldPacket const* packet)
 /// Add an incoming packet to the queue
 void WorldSession::QueuePacket(WorldPacket* new_packet)
 {
-    _recvQueue.add(new_packet);
+    m_mailbox->Enqueue(std::unique_ptr<WorldPacket>(new_packet));
 }
 
 /// Logging helper for unexpected opcodes
@@ -312,7 +307,7 @@ bool WorldSession::Update(PacketFilter& updater)
     ///- Retrieve packets from the receive queue and call the appropriate handlers
     /// not process packets if socket already closed
     WorldPacket* packet = nullptr;
-    while (m_link && !m_link->IsClosed() && _recvQueue.next(packet, updater))
+    while (m_link && !m_link->IsClosed() && m_mailbox->Next(packet, updater))
     {
         /*#if 1
         sLog.outError( "MOEP: %s (0x%.4X)",
@@ -368,7 +363,8 @@ bool WorldSession::Update(PacketFilter& updater)
                     break;
                 case STATUS_AUTHED:
                     // prevent cheating with skip queue wait
-                    if (m_inQueue)
+                    if (m_inQueue &&
+                        !IsAllowedWhileLoginQueued(packet->GetOpcode()))
                     {
                         LogUnexpectedOpcode(packet, "the player not pass queue yet");
                         break;
@@ -376,7 +372,8 @@ bool WorldSession::Update(PacketFilter& updater)
 
                     // single from authed time opcodes send in to after logout time
                     // and before other STATUS_LOGGEDIN_OR_RECENTLY_LOGGOUT opcodes.
-                    if (packet->GetOpcode() != CMSG_SET_ACTIVE_VOICE_CHANNEL)
+                    if (packet->GetOpcode() != CMSG_SET_ACTIVE_VOICE_CHANNEL &&
+                        !IsAllowedWhileLoginQueued(packet->GetOpcode()))
                     {
                         m_playerRecentlyLogout = false;
                     }
@@ -685,6 +682,39 @@ void WorldSession::KickPlayer()
     {
         m_link->Close();
     }
+}
+
+void WorldSession::HandlePingOpcode(WorldPacket& recvPacket)
+{
+    uint32 ping = 0;
+    uint32 latency = 0;
+    recvPacket >> ping;
+    recvPacket >> latency;
+
+    m_pingTracker.Record(SessionPingTracker::Clock::now());
+    uint32 maximum =
+        sWorld.getConfig(CONFIG_UINT32_MAX_OVERSPEED_PINGS);
+    if (m_pingTracker.ShouldKick(
+            maximum, GetSecurity() == SEC_PLAYER))
+    {
+        sLog.outError(
+            "WorldSession::HandlePingOpcode: Player kicked for "
+            "overspeeded pings address = %s",
+            GetRemoteAddress().c_str());
+        KickPlayer();
+        return;
+    }
+
+    SetLatency(latency);
+
+    WorldPacket response(SMSG_PONG, 4);
+    response << ping;
+    SendPacket(&response);
+}
+
+void WorldSession::HandleKeepAliveOpcode(WorldPacket& recvPacket)
+{
+    DEBUG_LOG("CMSG_KEEP_ALIVE ,size: %zu ", recvPacket.size());
 }
 
 /// Cancel channeling handler

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -29,7 +29,6 @@
 #ifndef MANGOS_H_WORLDSESSION
 #define MANGOS_H_WORLDSESSION
 
-#include "LockedQueue/LockedQueue.h"
 #include "Common/ServerDefines.h"
 #include "Platform/Define.h"
 #include "Common/Locales.h"
@@ -44,6 +43,7 @@
 #include "AuctionHouseMgr.h"
 #include "Item.h"
 #include "LFGMgr.h"
+#include "SessionProtocolPolicy.h"
 
 struct ItemPrototype;
 struct AuctionEntry;
@@ -59,6 +59,7 @@ class Player;
 class Unit;
 class Warden;
 class WorldPacket;
+class SessionMailbox;
 namespace proto
 {
     class IClientLink;
@@ -310,6 +311,7 @@ class WorldSession
          *             verify the login, and Warden needs it here.
          */
         WorldSession(uint32 id, std::shared_ptr<proto::IClientLink> link,
+                     std::shared_ptr<SessionMailbox> mailbox,
                      AccountTypes sec, uint8 expansion, time_t mute_time,
                      LocaleConstant locale, const BigNumber& sessionKey);
 
@@ -614,6 +616,7 @@ class WorldSession
         void HandleForceSpeedChangeAckOpcodes(WorldPacket& recv_data);
 
         void HandlePingOpcode(WorldPacket& recvPacket);
+        void HandleKeepAliveOpcode(WorldPacket& recvPacket);
         void HandleAuthSessionOpcode(WorldPacket& recvPacket);
         void HandleRepopRequestOpcode(WorldPacket& recvPacket);
         void HandleAutostoreLootItemOpcode(WorldPacket& recvPacket);
@@ -1084,6 +1087,7 @@ class WorldSession
         /// Channel back to the client. Null once the connection is gone; every
         /// call on it is safe after teardown, so callers need only null-check.
         std::shared_ptr<proto::IClientLink> m_link;
+        std::shared_ptr<SessionMailbox> m_mailbox;
 
         /// The account's session key, for Warden's HMAC. Owned here because it is
         /// account data, not transport state.
@@ -1107,11 +1111,11 @@ class WorldSession
         LocaleConstant m_sessionDbcLocale;
         int m_sessionDbLocaleIndex;
         uint32 m_latency;
+        SessionPingTracker m_pingTracker;
         AccountData m_accountData[NUM_ACCOUNT_DATA_TYPES];
         uint32 m_Tutorials[8];
         TutorialDataState m_tutorialState;
         AddonsList m_addonsList;
-        MaNGOS::LockedQueue<WorldPacket*> _recvQueue;
 };
 #endif
 /// @}

--- a/src/mangosd/mangosd.cpp
+++ b/src/mangosd/mangosd.cpp
@@ -308,7 +308,7 @@ int main(int argc, char** argv)
     if (!OpenSSLProviderManager::Instance().IsInitialized())
     {
         Log::WaitBeforeContinueIfNeed();
-        return 0;
+        return 1;
     }
 #else
     if (SSLeay() < 0x10100000L || SSLeay() > 0x10200000L)

--- a/src/proto/ClientConnection.cpp
+++ b/src/proto/ClientConnection.cpp
@@ -65,9 +65,7 @@ namespace proto
           m_codec(),
           m_seed(MakeAuthSeed()),
           m_session(INVALID_SESSION_ID),
-          m_closed(false),
-          m_hadPing(false),
-          m_fastPingRun(0)
+          m_closed(false)
     {
     }
 
@@ -149,9 +147,6 @@ namespace proto
                     return false;
                 }
                 return HandleAuthSession(packet);
-
-            case CMSG_PING:
-                return HandlePing(packet);
 
             default:
                 break;
@@ -262,55 +257,6 @@ namespace proto
 
         DEBUG_LOG("proto: account '%s' authenticated from %s",
                   request.account.c_str(), m_address.c_str());
-        return true;
-    }
-
-    bool ClientConnection::HandlePing(WorldPacket& packet)
-    {
-        uint32 ping    = 0;
-        uint32 latency = 0;
-
-        try
-        {
-            packet >> ping;
-            packet >> latency;
-        }
-        catch (ByteBufferException&)
-        {
-            sLog.outError("proto: truncated CMSG_PING from %s", m_address.c_str());
-            return false;
-        }
-
-        // The 3.3.5a client pings roughly every 30 seconds. Anything materially
-        // faster is either a broken client or someone probing, so count the run;
-        // a single early ping is jitter and must not be treated as either.
-        static const std::chrono::seconds MIN_PING_INTERVAL(27);
-
-        const std::chrono::steady_clock::time_point now =
-            std::chrono::steady_clock::now();
-
-        if (m_hadPing)
-        {
-            if (now - m_lastPing < MIN_PING_INTERVAL)
-            {
-                ++m_fastPingRun;
-            }
-            else
-            {
-                m_fastPingRun = 0;
-            }
-        }
-        m_lastPing = now;
-        m_hadPing  = true;
-
-        if (!m_gateway.OnPing(m_session, latency, m_fastPingRun))
-        {
-            return false;
-        }
-
-        WorldPacket pong(SMSG_PONG, 4);
-        pong << ping;
-        SendPacket(pong);
         return true;
     }
 

--- a/src/proto/ClientConnection.h
+++ b/src/proto/ClientConnection.h
@@ -35,7 +35,6 @@
 #include "net/ISession.hpp"
 
 #include <atomic>
-#include <chrono>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -111,7 +110,6 @@ namespace proto
             bool HandlePacket(WorldPacket&& packet);
 
             bool HandleAuthSession(WorldPacket& packet);
-            bool HandlePing(WorldPacket& packet);
 
             /// Send a bare SMSG_AUTH_RESPONSE carrying only a status byte.
             void SendAuthStatus(AuthStatus status);
@@ -136,15 +134,6 @@ namespace proto
 
             net::Sender m_sender;
             net::Closer m_closer;
-
-            /// When the previous CMSG_PING arrived; valid once m_hadPing is set.
-            std::chrono::steady_clock::time_point m_lastPing;
-            bool m_hadPing;
-
-            /// Consecutive pings that arrived faster than a real client sends
-            /// them. Reset the moment the cadence returns to normal, so ordinary
-            /// network jitter cannot accumulate into a kick.
-            uint32 m_fastPingRun;
     };
 }
 

--- a/src/proto/IWorldGateway.h
+++ b/src/proto/IWorldGateway.h
@@ -184,24 +184,6 @@ namespace proto
             virtual void Deliver(SessionId session, WorldPacket&& packet) = 0;
 
             /**
-             * @brief A client ping arrived.
-             *
-             * The protocol layer counts how many pings in a row arrived faster than
-             * a real client sends them, because that is a property of the stream.
-             * The world decides what the run is worth: the threshold is
-             * configuration, and staff accounts are exempt, which is session state.
-             *
-             * @param session      The session, or INVALID_SESSION_ID if the peer
-             *                     pinged before authenticating.
-             * @param latency      Round-trip time the client reported.
-             * @param fastPingRun  Number of consecutive suspiciously fast pings;
-             *                     zero once the client returns to a normal cadence.
-             * @return false to drop the connection.
-             */
-            virtual bool OnPing(SessionId session, uint32 latency,
-                                uint32 fastPingRun) = 0;
-
-            /**
              * @brief The connection is gone; release the session.
              *
              * The world may keep the session alive past this call to unwind game

--- a/src/shared/Auth/OpenSSLProvider.cpp
+++ b/src/shared/Auth/OpenSSLProvider.cpp
@@ -27,9 +27,14 @@
  * @brief Implementation of RAII wrappers for OpenSSL providers
  */
 
-#include <utility>
 #include "OpenSSLProvider.h"
 #include "Log/Log.h"
+
+#include <charconv>
+#include <cstdlib>
+#include <openssl/core_names.h>
+#include <openssl/params.h>
+#include <utility>
 
 /**
  * Creates a new OpenSSL cipher context wrapper.
@@ -81,6 +86,22 @@ OpenSSLCipherContext& OpenSSLCipherContext::operator=(OpenSSLCipherContext&& oth
 
 #if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
 
+namespace
+{
+bool ParseProviderMajor(const std::string& version, unsigned& major)
+{
+    std::size_t separator = version.find('.');
+    if (separator == std::string::npos || separator == 0)
+        return false;
+
+    const char* begin = version.data();
+    const char* end = begin + separator;
+    std::from_chars_result parsed =
+        std::from_chars(begin, end, major);
+    return parsed.ec == std::errc{} && parsed.ptr == end;
+}
+}
+
 /**
  * Loads the named OpenSSL provider into the specified library context.
  */
@@ -110,6 +131,22 @@ OpenSSLProvider::~OpenSSLProvider()
         OSSL_PROVIDER_unload(m_provider);
         m_provider = nullptr;
     }
+}
+
+std::string OpenSSLProvider::Version() const
+{
+    if (!m_provider)
+        return {};
+
+    char* version = nullptr;
+    OSSL_PARAM params[] = {
+        OSSL_PARAM_construct_utf8_ptr(
+            OSSL_PROV_PARAM_VERSION, &version, 0),
+        OSSL_PARAM_construct_end()
+    };
+    if (OSSL_PROVIDER_get_params(m_provider, params) != 1 || !version)
+        return {};
+    return version;
 }
 
 OpenSSLProvider::OpenSSLProvider(OpenSSLProvider&& other) noexcept
@@ -142,13 +179,7 @@ OpenSSLProvider& OpenSSLProvider::operator=(OpenSSLProvider&& other) noexcept
 OpenSSLProviderManager::OpenSSLProviderManager()
     : m_legacyProvider("legacy"), m_defaultProvider("default"), m_initialized(false)
 {
-    // Check if both providers loaded successfully
-    if (m_legacyProvider.IsLoaded() && m_defaultProvider.IsLoaded())
-    {
-        m_initialized = true;
-        sLog.outString("OpenSSL 3.x providers loaded successfully: legacy, default");
-    }
-    else
+    if (!m_legacyProvider.IsLoaded() || !m_defaultProvider.IsLoaded())
     {
         sLog.outError("Failed to load OpenSSL 3.x providers");
 
@@ -166,7 +197,49 @@ OpenSSLProviderManager::OpenSSLProviderManager()
         {
             sLog.outError("  - Default provider failed to load");
         }
+        return;
     }
+
+    std::string legacyVersion = m_legacyProvider.Version();
+    std::string defaultVersion = m_defaultProvider.Version();
+    unsigned legacyMajor = 0;
+    unsigned defaultMajor = 0;
+    bool parsedLegacy =
+        ParseProviderMajor(legacyVersion, legacyMajor);
+    bool parsedDefault =
+        ParseProviderMajor(defaultVersion, defaultMajor);
+
+    unsigned runtimeMajor =
+        unsigned((OpenSSL_version_num() >> 28) & 0x0f);
+    if (runtimeMajor != 3
+        || !parsedLegacy || legacyMajor != runtimeMajor
+        || !parsedDefault || defaultMajor != runtimeMajor)
+    {
+        const char* modules = std::getenv("OPENSSL_MODULES");
+        sLog.outError(
+            "OpenSSL 3.x provider/runtime validation failed: "
+            "runtime='%s', legacy provider='%s', default provider='%s', "
+            "OPENSSL_MODULES='%s'",
+            OpenSSL_version(OPENSSL_VERSION),
+            legacyVersion.empty() ? "<unavailable>" : legacyVersion.c_str(),
+            defaultVersion.empty() ? "<unavailable>" : defaultVersion.c_str(),
+            modules ? modules : "<unset>");
+        return;
+    }
+
+    EVP_CIPHER* rc4 = EVP_CIPHER_fetch(nullptr, "RC4", nullptr);
+    if (!rc4)
+    {
+        sLog.outError(
+            "OpenSSL legacy provider is loaded but RC4 is unavailable");
+        return;
+    }
+    EVP_CIPHER_free(rc4);
+
+    m_initialized = true;
+    sLog.outString(
+        "OpenSSL 3.x providers loaded successfully: legacy %s, default %s",
+        legacyVersion.c_str(), defaultVersion.c_str());
 }
 
 OpenSSLProviderManager& OpenSSLProviderManager::Instance()

--- a/src/shared/Auth/OpenSSLProvider.h
+++ b/src/shared/Auth/OpenSSLProvider.h
@@ -118,6 +118,12 @@ public:
     bool IsLoaded() const { return m_provider != nullptr; }
 
     /**
+     * @brief Get the version reported by the loaded provider
+     * @return Provider version, or an empty string if unavailable
+     */
+    std::string Version() const;
+
+    /**
      * @brief Get the underlying provider handle
      * @return OSSL_PROVIDER pointer or nullptr if not loaded
      */

--- a/src/shared/Database/Database.cpp
+++ b/src/shared/Database/Database.cpp
@@ -263,11 +263,10 @@ void Database::escape_string(std::string& str)
         return;
     }
 
-    char* buf = new char[str.size() * 2 + 1];
+    std::unique_ptr<char[]> buf(new char[str.size() * 2 + 1]);
     SqlConnection::Lock guard(m_pQueryConnections[0]);
-    guard->escape_string(buf, str.c_str(), str.size());
-    str = buf;
-    delete[] buf;
+    guard->escape_string(buf.get(), str.c_str(), str.size());
+    str = buf.get();
 }
 
 SqlConnection* Database::getQueryConnection()

--- a/src/shared/Database/Database.cpp
+++ b/src/shared/Database/Database.cpp
@@ -264,8 +264,8 @@ void Database::escape_string(std::string& str)
     }
 
     char* buf = new char[str.size() * 2 + 1];
-    // we don't care what connection to use - escape string will be the same
-    m_pQueryConnections[0]->escape_string(buf, str.c_str(), str.size());
+    SqlConnection::Lock guard(m_pQueryConnections[0]);
+    guard->escape_string(buf, str.c_str(), str.size());
     str = buf;
     delete[] buf;
 }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ set(SRC_GRP_TESTS
     TestHarness.h
     BigNumberTest.cpp
     ByteBufferTest.cpp
+    SessionMailboxTest.cpp
     ClientParserTest.cpp
     TerrainModelTest.cpp
     TileSerializerTest.cpp
@@ -42,6 +43,7 @@ set(SRC_GRP_TESTS
     # database globals that only mangosd defines. These two know nothing of it.
     ${CMAKE_SOURCE_DIR}/src/game/WorldHandlers/DynamicCollision.cpp
     ${CMAKE_SOURCE_DIR}/src/game/WorldHandlers/GameObjectModel.cpp
+    ${CMAKE_SOURCE_DIR}/src/game/Server/SessionMailbox.cpp
     ByteBufferStressTest.cpp
     CodecStressTest.cpp
     CryptoStressTest.cpp
@@ -53,7 +55,9 @@ source_group("tests" FILES ${SRC_GRP_TESTS})
 add_executable(mangos_tests ${SRC_GRP_TESTS})
 
 target_include_directories(mangos_tests
-    PRIVATE ${CMAKE_SOURCE_DIR}/src/game/WorldHandlers)
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/src/game/WorldHandlers
+        ${CMAKE_SOURCE_DIR}/src/game/Server)
 
 target_link_libraries(mangos_tests
     PRIVATE

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -35,6 +35,8 @@ set(SRC_GRP_TESTS
     ByteBufferTest.cpp
     SessionMailboxTest.cpp
     SessionProtocolPolicyTest.cpp
+    DatabaseConcurrencyTest.cpp
+    OpenSSLProviderTest.cpp
     ClientParserTest.cpp
     TerrainModelTest.cpp
     TileSerializerTest.cpp
@@ -70,9 +72,46 @@ target_link_libraries(mangos_tests
         mangos_openssl_strict
 )
 
+if(WIN32)
+    find_file(MANGOS_TEST_OPENSSL_CRYPTO_DLL
+        NAMES libcrypto-3-x64.dll libcrypto-3.dll
+        HINTS "${OPENSSL_ROOT_DIR}/bin"
+        NO_DEFAULT_PATH)
+    if(NOT MANGOS_TEST_OPENSSL_CRYPTO_DLL)
+        message(FATAL_ERROR
+            "Could not find the OpenSSL 3.x crypto runtime DLL under ${OPENSSL_ROOT_DIR}/bin")
+    endif()
+    add_custom_command(TARGET mangos_tests POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${MANGOS_TEST_OPENSSL_CRYPTO_DLL}"
+            "$<TARGET_FILE_DIR:mangos_tests>")
+
+    get_filename_component(
+        MANGOS_TEST_MYSQL_DLL_DIR "${MySQL_LIBRARY}" DIRECTORY)
+    get_filename_component(
+        MANGOS_TEST_MYSQL_DLL_NAME "${MySQL_LIBRARY}" NAME)
+    string(REPLACE ".lib" ".dll" MANGOS_TEST_MYSQL_DLL_NAME
+        "${MANGOS_TEST_MYSQL_DLL_NAME}")
+    add_custom_command(TARGET mangos_tests POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${MANGOS_TEST_MYSQL_DLL_DIR}/${MANGOS_TEST_MYSQL_DLL_NAME}"
+            "$<TARGET_FILE_DIR:mangos_tests>")
+
+endif()
+
 add_test(NAME mangos_tests COMMAND mangos_tests)
+
+if(WIN32)
+    set_tests_properties(mangos_tests PROPERTIES
+        ENVIRONMENT "OPENSSL_MODULES=${OPENSSL_ROOT_DIR}/bin")
+endif()
 
 add_test(NAME world_network_boundary
     COMMAND ${CMAKE_COMMAND}
         -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/CheckWorldNetworkBoundary.cmake)
+
+add_test(NAME build_policy
+    COMMAND ${CMAKE_COMMAND}
+        -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/CheckBuildPolicy.cmake)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(SRC_GRP_TESTS
     BigNumberTest.cpp
     ByteBufferTest.cpp
     SessionMailboxTest.cpp
+    SessionProtocolPolicyTest.cpp
     ClientParserTest.cpp
     TerrainModelTest.cpp
     TileSerializerTest.cpp
@@ -70,3 +71,8 @@ target_link_libraries(mangos_tests
 )
 
 add_test(NAME mangos_tests COMMAND mangos_tests)
+
+add_test(NAME world_network_boundary
+    COMMAND ${CMAKE_COMMAND}
+        -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/CheckWorldNetworkBoundary.cmake)

--- a/src/tests/CheckBuildPolicy.cmake
+++ b/src/tests/CheckBuildPolicy.cmake
@@ -1,0 +1,42 @@
+# MaNGOS is a full featured server for World of Warcraft, supporting
+# the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+#
+# Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+file(READ "${SOURCE_ROOT}/CMakeLists.txt" ROOT_CMAKE)
+file(READ "${SOURCE_ROOT}/src/mangosd/mangosd.cpp" MANGOSD_SOURCE)
+file(READ "${SOURCE_ROOT}/src/CMakeLists.txt" SRC_CMAKE)
+file(READ "${SOURCE_ROOT}/.github/workflows/core_linux_build.yml" LINUX_CI)
+file(READ "${SOURCE_ROOT}/.github/workflows/core_windows_build.yml" WINDOWS_CI)
+
+foreach(REQUIRED_TEXT
+    "find_package(OpenSSL 3.0 REQUIRED)"
+    "OPENSSL_VERSION VERSION_GREATER_EQUAL \"4.0.0\""
+    "OpenSSL 4.x support is intentionally deferred until the OpenSSL 4.2 LTS migration")
+  string(FIND "${ROOT_CMAKE}" "${REQUIRED_TEXT}" POSITION)
+  if(POSITION EQUAL -1)
+    message(FATAL_ERROR "Missing OpenSSL build policy: ${REQUIRED_TEXT}")
+  endif()
+endforeach()
+
+string(REGEX MATCH
+  "if \\(!OpenSSLProviderManager::Instance\\(\\)\\.IsInitialized\\(\\)\\)[^\n]*[\r\n]+[^\n]*\\{[\r\n]+[^\n]*Log::WaitBeforeContinueIfNeed\\(\\);[\r\n]+[^\n]*return 1;"
+  PROVIDER_FAILURE "${MANGOSD_SOURCE}")
+if(NOT PROVIDER_FAILURE)
+  message(FATAL_ERROR "mangosd provider failure must return 1")
+endif()
+
+string(FIND "${SRC_CMAKE}" "Upstream realmd passes the *file*" POSITION)
+if(NOT POSITION EQUAL -1)
+  message(FATAL_ERROR "Obsolete external realmd VersionInfo workaround remains")
+endif()

--- a/src/tests/CheckBuildPolicy.cmake
+++ b/src/tests/CheckBuildPolicy.cmake
@@ -40,3 +40,18 @@ string(FIND "${SRC_CMAKE}" "Upstream realmd passes the *file*" POSITION)
 if(NOT POSITION EQUAL -1)
   message(FATAL_ERROR "Obsolete external realmd VersionInfo workaround remains")
 endif()
+
+foreach(CI_TEXT IN ITEMS "${LINUX_CI}" "${WINDOWS_CI}")
+  foreach(REQUIRED_TEXT "-DWITH_TESTS=1" "ctest --test-dir")
+    string(FIND "${CI_TEXT}" "${REQUIRED_TEXT}" POSITION)
+    if(POSITION EQUAL -1)
+      message(FATAL_ERROR "CI does not run tests: ${REQUIRED_TEXT}")
+    endif()
+  endforeach()
+endforeach()
+
+string(REGEX MATCH "OPENSSL_VERSION: 3\\.[0-9]+\\.[0-9]+"
+  OPENSSL_PIN "${WINDOWS_CI}")
+if(NOT OPENSSL_PIN)
+  message(FATAL_ERROR "Windows CI is not pinned to OpenSSL 3.x")
+endif()

--- a/src/tests/CheckWorldNetworkBoundary.cmake
+++ b/src/tests/CheckWorldNetworkBoundary.cmake
@@ -1,0 +1,82 @@
+# MaNGOS is a full featured server for World of Warcraft, supporting
+# the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+#
+# Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+file(READ "${SOURCE_ROOT}/src/game/Server/WorldGateway.h" GATEWAY_HEADER)
+file(READ "${SOURCE_ROOT}/src/game/Server/WorldGateway.cpp" GATEWAY_SOURCE)
+file(READ "${SOURCE_ROOT}/src/game/Server/WorldSession.h" SESSION_HEADER)
+file(READ "${SOURCE_ROOT}/src/game/Server/WorldSession.cpp" SESSION_SOURCE)
+file(READ "${SOURCE_ROOT}/src/proto/IWorldGateway.h" PROTO_GATEWAY)
+file(READ "${SOURCE_ROOT}/src/proto/ClientConnection.cpp" CLIENT_SOURCE)
+file(READ "${SOURCE_ROOT}/src/game/Server/OpcodeTable.cpp" OPCODE_SOURCE)
+
+foreach(REQUIRED_TEXT
+    "std::unordered_map<proto::SessionId, std::shared_ptr<SessionMailbox>> m_routes"
+    "std::shared_ptr<SessionMailbox> mailbox"
+    "mailbox->Enqueue"
+    "mailbox->Close")
+  string(FIND "${GATEWAY_HEADER}\n${GATEWAY_SOURCE}"
+    "${REQUIRED_TEXT}" POSITION)
+  if(POSITION EQUAL -1)
+    message(FATAL_ERROR "Missing mailbox route invariant: ${REQUIRED_TEXT}")
+  endif()
+endforeach()
+
+foreach(FORBIDDEN_TEXT
+    "virtual bool OnPing"
+    "ClientConnection::HandlePing"
+    "m_gateway.OnPing")
+  string(FIND "${PROTO_GATEWAY}\n${CLIENT_SOURCE}"
+    "${FORBIDDEN_TEXT}" POSITION)
+  if(NOT POSITION EQUAL -1)
+    message(FATAL_ERROR "Protocol-side game policy remains: ${FORBIDDEN_TEXT}")
+  endif()
+endforeach()
+
+foreach(REQUIRED_TEXT
+    "OPCODE(CMSG_PING,                                      STATUS_AUTHED,   PROCESS_THREADUNSAFE, &WorldSession::HandlePingOpcode)"
+    "OPCODE(CMSG_KEEP_ALIVE,                                STATUS_AUTHED,   PROCESS_THREADUNSAFE, &WorldSession::HandleKeepAliveOpcode)"
+    "IsAllowedWhileLoginQueued(packet->GetOpcode())"
+    "void WorldSession::HandlePingOpcode"
+    "void WorldSession::HandleKeepAliveOpcode")
+  string(FIND "${OPCODE_SOURCE}\n${SESSION_SOURCE}"
+    "${REQUIRED_TEXT}" POSITION)
+  if(POSITION EQUAL -1)
+    message(FATAL_ERROR "Missing world-thread policy: ${REQUIRED_TEXT}")
+  endif()
+endforeach()
+
+foreach(FORBIDDEN_TEXT
+    "std::unordered_map<proto::SessionId, WorldSession*>"
+    "WorldSession* Find("
+    "target->QueuePacket"
+    "target->KickPlayer")
+  string(FIND "${GATEWAY_HEADER}\n${GATEWAY_SOURCE}"
+    "${FORBIDDEN_TEXT}" POSITION)
+  if(NOT POSITION EQUAL -1)
+    message(FATAL_ERROR "Raw session route remains: ${FORBIDDEN_TEXT}")
+  endif()
+endforeach()
+
+foreach(REQUIRED_TEXT
+    "std::shared_ptr<SessionMailbox> m_mailbox"
+    "m_mailbox->Close()"
+    "m_mailbox->Enqueue"
+    "m_mailbox->Next")
+  string(FIND "${SESSION_HEADER}\n${SESSION_SOURCE}"
+    "${REQUIRED_TEXT}" POSITION)
+  if(POSITION EQUAL -1)
+    message(FATAL_ERROR "Missing session mailbox invariant: ${REQUIRED_TEXT}")
+  endif()
+endforeach()

--- a/src/tests/CheckWorldNetworkBoundary.cmake
+++ b/src/tests/CheckWorldNetworkBoundary.cmake
@@ -24,6 +24,7 @@ file(READ "${SOURCE_ROOT}/src/game/Server/OpcodeTable.cpp" OPCODE_SOURCE)
 foreach(REQUIRED_TEXT
     "std::unordered_map<proto::SessionId, std::shared_ptr<SessionMailbox>> m_routes"
     "std::shared_ptr<SessionMailbox> mailbox"
+    "WorldSession* published = session.release()"
     "mailbox->Enqueue"
     "mailbox->Close")
   string(FIND "${GATEWAY_HEADER}\n${GATEWAY_SOURCE}"
@@ -73,7 +74,10 @@ foreach(REQUIRED_TEXT
     "std::shared_ptr<SessionMailbox> m_mailbox"
     "m_mailbox->Close()"
     "m_mailbox->Enqueue"
-    "m_mailbox->Next")
+    "m_mailbox->Next"
+    "if (m_link && m_link->IsClosed())"
+    "m_link.reset()"
+    "return false;                                    // Will remove this session from the world session map")
   string(FIND "${SESSION_HEADER}\n${SESSION_SOURCE}"
     "${REQUIRED_TEXT}" POSITION)
   if(POSITION EQUAL -1)

--- a/src/tests/DatabaseConcurrencyTest.cpp
+++ b/src/tests/DatabaseConcurrencyTest.cpp
@@ -1,0 +1,164 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "TestHarness.h"
+#include "Database/QueryResult.h"
+#include "Database/Database.h"
+
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+class FakeConnection final : public SqlConnection
+{
+    public:
+        explicit FakeConnection(Database& database)
+            : SqlConnection(database)
+        {
+        }
+
+        bool Initialize(const char*) override { return true; }
+
+        QueryResult* Query(const char*) override
+        {
+            Enter();
+            queryEntered.store(true);
+            if (coordinateEscape)
+            {
+                while (!escapeAttempting.load())
+                    std::this_thread::yield();
+                std::this_thread::sleep_for(
+                    std::chrono::milliseconds(20));
+            }
+            else
+            {
+                std::this_thread::sleep_for(
+                    std::chrono::milliseconds(1));
+            }
+            Leave();
+            return nullptr;
+        }
+
+        QueryNamedResult* QueryNamed(const char*) override
+        {
+            return nullptr;
+        }
+
+        bool Execute(const char*) override { return true; }
+
+        unsigned long escape_string(
+            char* to, const char* from,
+            unsigned long length) override
+        {
+            Enter();
+            for (unsigned long i = 0; i < length; ++i)
+                to[i] = from[i];
+            to[length] = '\0';
+            Leave();
+            return length;
+        }
+
+        void Enter()
+        {
+            if (active.fetch_add(1) != 0)
+                overlap.store(true);
+        }
+
+        void Leave()
+        {
+            active.fetch_sub(1);
+        }
+
+        std::atomic<int> active{0};
+        std::atomic<bool> overlap{false};
+        std::atomic<bool> queryEntered{false};
+        std::atomic<bool> escapeAttempting{false};
+        bool coordinateEscape = false;
+};
+
+class FakeDatabase final : public Database
+{
+    public:
+        FakeDatabase()
+        {
+            m_connection = new FakeConnection(*this);
+            m_pQueryConnections.push_back(m_connection);
+            m_nQueryConnPoolSize = 1;
+        }
+
+        FakeConnection& Connection() { return *m_connection; }
+
+    protected:
+        SqlConnection* CreateConnection() override
+        {
+            return new FakeConnection(*this);
+        }
+
+    private:
+        FakeConnection* m_connection = nullptr;
+};
+}
+
+TEST(Database_queries_serialize_on_connection_lock)
+{
+    FakeDatabase database;
+    std::vector<std::thread> threads;
+    for (unsigned i = 0; i < 8; ++i)
+    {
+        threads.emplace_back([&database]()
+        {
+            for (unsigned query = 0; query < 3; ++query)
+                database.PQuery("SELECT %u", query);
+        });
+    }
+    for (std::thread& thread : threads)
+        thread.join();
+
+    CHECK(!database.Connection().overlap.load());
+}
+
+TEST(Database_escape_shares_connection_zero_lock)
+{
+    FakeDatabase database;
+    FakeConnection& connection = database.Connection();
+    connection.coordinateEscape = true;
+
+    std::thread query([&database]() { database.PQuery("SELECT 1"); });
+    std::thread escape([&database, &connection]()
+    {
+        while (!connection.queryEntered.load())
+            std::this_thread::yield();
+        connection.escapeAttempting.store(true);
+        std::string value = "account'name";
+        database.escape_string(value);
+    });
+
+    query.join();
+    escape.join();
+    CHECK(!connection.overlap.load());
+}

--- a/src/tests/OpenSSLProviderTest.cpp
+++ b/src/tests/OpenSSLProviderTest.cpp
@@ -1,0 +1,67 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "TestHarness.h"
+#include "Auth/OpenSSLProvider.h"
+
+#include <charconv>
+#include <openssl/crypto.h>
+#include <openssl/evp.h>
+
+TEST(OpenSSL_runtime_and_providers_are_major_three)
+{
+    OpenSSLProviderManager& manager =
+        OpenSSLProviderManager::Instance();
+    REQUIRE(manager.IsInitialized());
+
+    unsigned runtimeMajor =
+        unsigned((OpenSSL_version_num() >> 28) & 0x0f);
+    CHECK_EQ(runtimeMajor, 3);
+
+    auto checkProvider = [runtimeMajor](
+        const OpenSSLProvider& provider)
+    {
+        std::string version = provider.Version();
+        REQUIRE(!version.empty());
+        std::size_t separator = version.find('.');
+        REQUIRE(separator != std::string::npos);
+        unsigned major = 0;
+        std::from_chars_result result = std::from_chars(
+            version.data(), version.data() + separator, major);
+        CHECK(result.ec == std::errc{});
+        CHECK(result.ptr == version.data() + separator);
+        CHECK_EQ(major, runtimeMajor);
+    };
+
+    checkProvider(manager.GetLegacyProvider());
+    checkProvider(manager.GetDefaultProvider());
+}
+
+TEST(OpenSSL_legacy_provider_supplies_rc4)
+{
+    REQUIRE(OpenSSLProviderManager::Instance().IsInitialized());
+    EVP_CIPHER* rc4 = EVP_CIPHER_fetch(nullptr, "RC4", nullptr);
+    CHECK(rc4 != nullptr);
+    EVP_CIPHER_free(rc4);
+}

--- a/src/tests/SessionMailboxTest.cpp
+++ b/src/tests/SessionMailboxTest.cpp
@@ -1,0 +1,124 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "TestHarness.h"
+#include "SessionMailbox.h"
+
+#include <atomic>
+#include <memory>
+#include <thread>
+#include <vector>
+
+namespace
+{
+std::unique_ptr<WorldPacket> MakePacket(uint16 opcode, uint8 value)
+{
+    std::unique_ptr<WorldPacket> packet =
+        std::make_unique<WorldPacket>(opcode, 1);
+    *packet << value;
+    return packet;
+}
+}
+
+TEST(SessionMailbox_transfers_fifo_ownership)
+{
+    SessionMailbox mailbox;
+    CHECK(mailbox.Enqueue(MakePacket(1, 0x11)));
+    CHECK(mailbox.Enqueue(MakePacket(2, 0x22)));
+
+    WorldPacket* raw = nullptr;
+    REQUIRE(mailbox.Next(raw));
+    std::unique_ptr<WorldPacket> first(raw);
+    CHECK_EQ(first->GetOpcode(), 1);
+    CHECK_EQ((*first)[0], 0x11);
+
+    REQUIRE(mailbox.Next(raw));
+    std::unique_ptr<WorldPacket> second(raw);
+    CHECK_EQ(second->GetOpcode(), 2);
+    CHECK_EQ((*second)[0], 0x22);
+    CHECK(!mailbox.Next(raw));
+}
+
+TEST(SessionMailbox_close_is_idempotent_and_drains)
+{
+    SessionMailbox mailbox;
+    CHECK(mailbox.Enqueue(MakePacket(3, 0x33)));
+    CHECK(mailbox.Enqueue(MakePacket(4, 0x44)));
+
+    mailbox.Close();
+    mailbox.Close();
+
+    WorldPacket* raw = nullptr;
+    CHECK(mailbox.IsClosed());
+    CHECK(!mailbox.Next(raw));
+    CHECK(!mailbox.Enqueue(MakePacket(5, 0x55)));
+}
+
+TEST(SessionMailbox_close_racing_producers_leaves_no_packets)
+{
+    SessionMailbox mailbox;
+    std::atomic<bool> start{false};
+    std::vector<std::thread> producers;
+    for (unsigned producer = 0; producer < 4; ++producer)
+    {
+        producers.emplace_back([&mailbox, &start, producer]()
+        {
+            while (!start.load())
+                std::this_thread::yield();
+            for (unsigned packet = 0; packet < 200; ++packet)
+            {
+                mailbox.Enqueue(MakePacket(
+                    uint16(producer + 1), uint8(packet)));
+            }
+        });
+    }
+
+    start.store(true);
+    mailbox.Close();
+    for (std::thread& producer : producers)
+        producer.join();
+
+    WorldPacket* raw = nullptr;
+    CHECK(!mailbox.Next(raw));
+    CHECK(!mailbox.Enqueue(MakePacket(9, 0x99)));
+}
+
+TEST(SessionMailbox_closed_old_route_cannot_reach_replacement)
+{
+    std::shared_ptr<SessionMailbox> oldMailbox =
+        std::make_shared<SessionMailbox>();
+    std::shared_ptr<SessionMailbox> retainedDelivery = oldMailbox;
+    oldMailbox->Close();
+
+    std::shared_ptr<SessionMailbox> replacement =
+        std::make_shared<SessionMailbox>();
+    CHECK(!retainedDelivery->Enqueue(MakePacket(6, 0x66)));
+    CHECK(replacement->Enqueue(MakePacket(7, 0x77)));
+
+    WorldPacket* raw = nullptr;
+    REQUIRE(replacement->Next(raw));
+    std::unique_ptr<WorldPacket> packet(raw);
+    CHECK_EQ(packet->GetOpcode(), 7);
+    CHECK(!replacement->Next(raw));
+}

--- a/src/tests/SessionMailboxTest.cpp
+++ b/src/tests/SessionMailboxTest.cpp
@@ -79,14 +79,23 @@ TEST(SessionMailbox_close_racing_producers_leaves_no_packets)
 {
     SessionMailbox mailbox;
     std::atomic<bool> start{false};
+    std::atomic<unsigned> ready{0};
+    std::atomic<bool> raceClose{false};
     std::vector<std::thread> producers;
     for (unsigned producer = 0; producer < 4; ++producer)
     {
-        producers.emplace_back([&mailbox, &start, producer]()
+        producers.emplace_back(
+            [&mailbox, &start, &ready, &raceClose, producer]()
         {
             while (!start.load())
                 std::this_thread::yield();
-            for (unsigned packet = 0; packet < 200; ++packet)
+
+            mailbox.Enqueue(MakePacket(uint16(producer + 1), 0));
+            ready.fetch_add(1);
+            while (!raceClose.load())
+                std::this_thread::yield();
+
+            for (unsigned packet = 1; packet < 200; ++packet)
             {
                 mailbox.Enqueue(MakePacket(
                     uint16(producer + 1), uint8(packet)));
@@ -95,6 +104,9 @@ TEST(SessionMailbox_close_racing_producers_leaves_no_packets)
     }
 
     start.store(true);
+    while (ready.load() != producers.size())
+        std::this_thread::yield();
+    raceClose.store(true);
     mailbox.Close();
     for (std::thread& producer : producers)
         producer.join();

--- a/src/tests/SessionProtocolPolicyTest.cpp
+++ b/src/tests/SessionProtocolPolicyTest.cpp
@@ -1,0 +1,66 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "TestHarness.h"
+#include "SessionProtocolPolicy.h"
+
+using namespace std::chrono;
+
+TEST(SessionPingTracker_first_ping_is_not_fast)
+{
+    SessionPingTracker tracker;
+    CHECK_EQ(tracker.Record(
+        SessionPingTracker::Clock::time_point(seconds(100))), 0);
+    CHECK(!tracker.ShouldKick(1, true));
+}
+
+TEST(SessionPingTracker_counts_and_resets_fast_runs)
+{
+    SessionPingTracker tracker;
+    SessionPingTracker::Clock::time_point start(seconds(100));
+    CHECK_EQ(tracker.Record(start), 0);
+    CHECK_EQ(tracker.Record(start + seconds(10)), 1);
+    CHECK_EQ(tracker.Record(start + seconds(20)), 2);
+    CHECK_EQ(tracker.Record(start + seconds(50)), 0);
+}
+
+TEST(SessionPingTracker_enforces_threshold_only_for_players)
+{
+    SessionPingTracker tracker;
+    SessionPingTracker::Clock::time_point start(seconds(100));
+    tracker.Record(start);
+    tracker.Record(start + seconds(1));
+    tracker.Record(start + seconds(2));
+
+    CHECK(tracker.ShouldKick(1, true));
+    CHECK(!tracker.ShouldKick(0, true));
+    CHECK(!tracker.ShouldKick(1, false));
+}
+
+TEST(SessionQueuePolicy_allows_only_ping_and_keepalive)
+{
+    CHECK(IsAllowedWhileLoginQueued(CMSG_PING));
+    CHECK(IsAllowedWhileLoginQueued(CMSG_KEEP_ALIVE));
+    CHECK(!IsAllowedWhileLoginQueued(CMSG_CHAR_ENUM));
+}


### PR DESCRIPTION
## Summary

- route authenticated client packets through an ownership-safe `SessionMailbox` instead of exposing raw `WorldSession` objects to the protocol layer
- move ping cadence, pong handling, overspeed enforcement, latency updates, and login-queue opcode policy onto the world thread
- make session publication, detachment, and shutdown ownership explicit while preserving the existing IOCP lifecycle
- serialize database escaping through query connection zero
- require OpenSSL `>=3.0.0` and `<4.0.0`, validate provider/runtime compatibility and RC4 availability at startup, and keep the OpenSSL 4.2 LTS migration explicitly deferred
- advance the `realmd` submodule to `39b78467d708263de9570fb9376fc9278912e01e`
- run the networking, database, OpenSSL, and boundary regression coverage in Linux and Windows CI

## Motivation

The protocol transport still knew about world-session lifetime and game policy. That coupled socket delivery to database-backed session construction, queue rules, ping enforcement, and world ownership. It also allowed packet delivery through raw session pointers across the network/world boundary.

This change keeps `src/proto` responsible for framing, authentication proof, cryptography, and transport. The game side owns authenticated packet queues and consumes them on the world thread, where session state and policy already live.

## Compatibility

- preserves WotLK 3.3.5a authentication, addon ordering, Warden initialization, opcode values, and header cipher behavior
- preserves the newer IOCP callback/lifecycle guarantees
- preserves the existing world-session reap path after transport closure
- accepts OpenSSL 3.x only; OpenSSL 4 support remains deferred until the 4.2 LTS migration
- rebased cleanly onto terrain seam squash commit `ac28ad4fdba22eddcb6832acde2c911a987a663c`

## Validation

- fresh MSVC/Ninja configure pinned to OpenSSL 3.6.2
- complete build of all default targets, including `mangosd`, `realmd`, tests, and extractor
- CTest: 3/3 passed (`mangos_tests`, `world_network_boundary`, and `build_policy`)
- deployed daemon hashes matched the build outputs exactly
- dependency inspection confirmed both daemons and tests import `libcrypto-3-x64.dll`, with no OpenSSL 4 dependency
- focused `cppcheck` pass found no issue in newly added lines; its nonzero result came from existing project/header warnings outside this diff
- deployed Windows runtime smoke test passed (user reported)
- focused Claude review initially raised lifecycle questions; after tracing the existing reap and IOCP serialization paths and applying four concrete hardening fixes, the focused re-review concluded `APPROVE` with no blocking or important findings

## Scope

No terrain, gameplay, addon-ordering, or unrelated database refactor is included. Internal plans, prompts, and review ledgers remain outside the repository.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/245)
<!-- Reviewable:end -->
