### PR TITLE
Re-home world packet logging into WorldGateway/WorldSession

### DIFF
--- a/src/game/Server/WorldGateway.cpp
+++ b/src/game/Server/WorldGateway.cpp
@@ -33,6 +33,7 @@
 #include "DBCStores.h"
 #include "Database/DatabaseEnv.h"
 #include "Log/Log.h"
+#include "OpcodeTable.h"
 #include "SharedDefines.h"
 #include "SessionMailbox.h"
 #include "World.h"
@@ -319,6 +320,16 @@ void WorldGateway::Deliver(proto::SessionId session, WorldPacket&& packet)
             return;
         }
         mailbox = route->second;
+    }
+
+    // Dump incoming packet (opt-in via PacketLoggingEnabled; off by default).
+    // WorldSocket.cpp did this with the ACE socket fd as the "SOCKET:" field;
+    // the proto SessionId is the modern equivalent -- a slot assigned once at
+    // Attach() and released at Detach(), same lifetime shape as a fd.
+    if (sLog.IsPacketLoggingEnabled())
+    {
+        sLog.outWorldPacketDump(session, packet.GetOpcode(),
+                                LookupOpcodeName(packet.GetOpcode()), &packet, true);
     }
 
     mailbox->Enqueue(std::make_unique<WorldPacket>(std::move(packet)));

--- a/src/game/Server/WorldSession.cpp
+++ b/src/game/Server/WorldSession.cpp
@@ -274,6 +274,19 @@ void WorldSession::SendPacket(WorldPacket const* packet)
 
 #endif                                                  // !MANGOS_DEBUG
 
+    // Dump outgoing packet (opt-in via PacketLoggingEnabled; off by default).
+    // WorldSocket.cpp did this with the ACE socket fd as the "SOCKET:" field;
+    // WorldSession has no proto::SessionId of its own to mirror that with (the
+    // gateway keys sessions the other way, WorldSession -> nothing), so the
+    // account id fills the same "stable per-connection identifier" role here
+    // -- it does not change across a reconnect the way a freshly assigned
+    // slot id would.
+    if (sLog.IsPacketLoggingEnabled())
+    {
+        sLog.outWorldPacketDump(GetAccountId(), packet->GetOpcode(),
+                                LookupOpcodeName(packet->GetOpcode()), packet, false);
+    }
+
     // No error to check any more: the link queues the bytes and the transport
     // owns delivery. A send on a dead connection is discarded, not a failure the
     // caller has to unwind.

--- a/src/shared/Log/Log.h
+++ b/src/shared/Log/Log.h
@@ -309,6 +309,9 @@ class Log : public MaNGOS::Singleton<Log>
         /**
          * @brief any log level
          *
+         * Called from WorldGateway::Deliver (incoming) and WorldSession::SendPacket
+         * (outgoing) -- see IsPacketLoggingEnabled()'s comment below.
+         *
          * @param socket
          * @param opcode
          * @param opcodeName
@@ -465,6 +468,10 @@ class Log : public MaNGOS::Singleton<Log>
          *        PacketLoggingEnabled config flag at startup: worldLogfile is
          *        only opened when the flag is set, so this is the single source
          *        of truth and is off by default even on legacy configs.
+         *
+         *        Hooked into WorldGateway::Deliver (incoming) and
+         *        WorldSession::SendPacket (outgoing) -- not into proto, which
+         *        must stay game-agnostic and does not resolve opcode names.
          * @return bool
          */
         bool IsPacketLoggingEnabled() const { return worldLogfile != NULL; }


### PR DESCRIPTION
`Log::outWorldPacketDump` was orphaned when WorldSocket was deleted in the ACE removal (#240) — `PacketLoggingEnabled = 1` has produced no dump since.

Re-homes it game-side: `WorldGateway::Deliver` (incoming, after the session-mailbox lookup) and `WorldSession::SendPacket` (outgoing), gated on `IsPacketLoggingEnabled()`, using `LookupOpcodeName` for opcode names.

Paired with the equivalent mangosthree change, mangosthree/server#304 (its ACE-removal phase 2). Build green (game + mangosd targets).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/246)
<!-- Reviewable:end -->
