### PR TITLE
[Fix] Group: test the raid flag as a bit

### DIFF
--- a/src/game/WorldHandlers/Group.h
+++ b/src/game/WorldHandlers/Group.h
@@ -308,11 +308,13 @@ class Group
         ObjectGuid GetObjectGuid() const { return ObjectGuid(HIGHGUID_GROUP, GetId()); }
         bool IsFull() const
         {
-            return (m_groupType == GROUPTYPE_NORMAL) ? (m_memberSlots.size() >= MAX_GROUP_SIZE) : (m_memberSlots.size() >= MAX_RAID_SIZE);
+            return isRaidGroup() ? (m_memberSlots.size() >= MAX_RAID_SIZE) : (m_memberSlots.size() >= MAX_GROUP_SIZE);
         }
+        /// m_groupType is a flag set, so test the bit; an equality check misses
+        /// GROUPTYPE_BGRAID and any future flag OR-ed alongside it.
         bool isRaidGroup() const
         {
-            return m_groupType == GROUPTYPE_RAID;
+            return (m_groupType & GROUPTYPE_RAID) != 0;
         }
         bool isBGGroup()   const
         {


### PR DESCRIPTION
Paired with mangosthree/server#319, which carries the same fix — the bug is identical
in both forks.

`m_groupType` is a flag set, so `m_groupType == GROUPTYPE_RAID` is false for a
battleground raid (`GROUPTYPE_BGRAID = GROUPTYPE_BG | GROUPTYPE_RAID`). Those did not
count as raids, which quietly disabled assistants, main tank/main assistant and
subgroup moves in battlegrounds. `IsFull()` had the mirror image of the same bug and
is now expressed in terms of `isRaidGroup()`.

`GROUPTYPE_BG` is never set on its own — only ever as part of `GROUPTYPE_BGRAID` — so
the only behaviour changes are those corrections, plus LFD groups capping at 5 rather
than 40.

`game.lib` builds clean.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/256)
<!-- Reviewable:end -->
