### PR TITLE
[Log] Attribute each packet dump to its session instead of "SOCKET"

### DIFF
--- a/src/game/Server/WorldGateway.cpp
+++ b/src/game/Server/WorldGateway.cpp
@@ -311,6 +311,19 @@ proto::SessionId WorldGateway::Attach(const proto::AuthRequest& request,
     return id;
 }
 
+void WorldGateway::TracePacket(proto::SessionId session, const WorldPacket& packet,
+                               bool incoming)
+{
+    // Both directions, from the one place that sees every packet on the wire. It used to
+    // be two: this side keyed on the SessionId, WorldSession::SendPacket on the account
+    // id, so one field carried two numbering schemes and named neither.
+    if (sLog.IsPacketLoggingEnabled())
+    {
+        sLog.outWorldPacketDump(session, packet.GetOpcode(),
+                                LookupOpcodeName(packet.GetOpcode()), &packet, incoming);
+    }
+}
+
 void WorldGateway::Deliver(proto::SessionId session, WorldPacket&& packet)
 {
     std::shared_ptr<SessionMailbox> mailbox;
@@ -322,16 +335,6 @@ void WorldGateway::Deliver(proto::SessionId session, WorldPacket&& packet)
             return;
         }
         mailbox = route->second;
-    }
-
-    // Dump incoming packet (opt-in via PacketLoggingEnabled; off by default).
-    // WorldSocket.cpp did this with the ACE socket fd as the "SOCKET:" field;
-    // the proto SessionId is the modern equivalent -- a slot assigned once at
-    // Attach() and released at Detach(), same lifetime shape as a fd.
-    if (sLog.IsPacketLoggingEnabled())
-    {
-        sLog.outWorldPacketDump(session, packet.GetOpcode(),
-                                LookupOpcodeName(packet.GetOpcode()), &packet, true);
     }
 
     mailbox->Enqueue(std::make_unique<WorldPacket>(std::move(packet)));

--- a/src/game/Server/WorldGateway.h
+++ b/src/game/Server/WorldGateway.h
@@ -62,6 +62,9 @@ class WorldGateway : public proto::IWorldGateway
                                 const std::shared_ptr<proto::IClientLink>& link,
                                 const std::shared_ptr<proto::AuthContext>& context) override;
 
+        void TracePacket(proto::SessionId session, const WorldPacket& packet,
+                         bool incoming) override;
+
         void Deliver(proto::SessionId session, WorldPacket&& packet) override;
 
         void Detach(proto::SessionId session) override;

--- a/src/game/Server/WorldSession.cpp
+++ b/src/game/Server/WorldSession.cpp
@@ -276,18 +276,10 @@ void WorldSession::SendPacket(WorldPacket const* packet)
 
 #endif                                                  // !MANGOS_DEBUG
 
-    // Dump outgoing packet (opt-in via PacketLoggingEnabled; off by default).
-    // WorldSocket.cpp did this with the ACE socket fd as the "SOCKET:" field;
-    // WorldSession has no proto::SessionId of its own to mirror that with (the
-    // gateway keys sessions the other way, WorldSession -> nothing), so the
-    // account id fills the same "stable per-connection identifier" role here
-    // -- it does not change across a reconnect the way a freshly assigned
-    // slot id would.
-    if (sLog.IsPacketLoggingEnabled())
-    {
-        sLog.outWorldPacketDump(GetAccountId(), packet->GetOpcode(),
-                                LookupOpcodeName(packet->GetOpcode()), packet, false);
-    }
+    // The dump is NOT taken here any more. The account id this used to key it on was a
+    // different numbering scheme from the SessionId the incoming side used, so the two
+    // halves of one log could not be told apart. ClientConnection traces both directions
+    // now, which also catches what never reaches this function: the auth handshake.
 
     // No error to check any more: the link queues the bytes and the transport
     // owns delivery. A send on a dead connection is discarded, not a failure the

--- a/src/proto/ClientConnection.cpp
+++ b/src/proto/ClientConnection.cpp
@@ -68,6 +68,7 @@ namespace proto
           m_codec(),
           m_seed(MakeAuthSeed()),
           m_session(INVALID_SESSION_ID),
+          m_traceSession(INVALID_SESSION_ID),
           m_closed(false)
     {
         s_openConnections.fetch_add(1, std::memory_order_relaxed);
@@ -96,6 +97,7 @@ namespace proto
 
         // The crypt is not armed yet, so this goes out in clear text -- which is
         // exactly right: the client cannot key its cipher until it has this packet.
+        m_gateway.TracePacket(INVALID_SESSION_ID, packet, false);
         return PacketCodec::Encode(packet, PacketCodec::HeaderEncryptor());
     }
 
@@ -118,6 +120,9 @@ namespace proto
         {
             for (size_t i = 0; i < packets.size(); ++i)
             {
+                // Before the move, which empties it.
+                m_gateway.TracePacket(m_traceSession.load(std::memory_order_relaxed),
+                                      packets[i], true);
                 if (!HandlePacket(std::move(packets[i])))
                 {
                     Close();
@@ -259,6 +264,7 @@ namespace proto
         }
 
         m_session = session;
+        m_traceSession.store(session, std::memory_order_relaxed);
 
         DEBUG_LOG("proto: account '%s' authenticated from %s",
                   request.account.c_str(), m_address.c_str());
@@ -278,6 +284,8 @@ namespace proto
         {
             return;
         }
+
+        m_gateway.TracePacket(m_traceSession.load(std::memory_order_relaxed), packet, false);
 
         std::vector<uint8_t> wire;
         {
@@ -315,5 +323,6 @@ namespace proto
             m_gateway.Detach(m_session);
             m_session = INVALID_SESSION_ID;
         }
+        m_traceSession.store(INVALID_SESSION_ID, std::memory_order_relaxed);
     }
 }

--- a/src/proto/ClientConnection.h
+++ b/src/proto/ClientConnection.h
@@ -137,6 +137,12 @@ namespace proto
 
             SessionId m_session;
 
+            /// The same id, readable off the network thread. SendPacket runs on the
+            /// world thread while m_session is written here on the network thread, so
+            /// the trace needs a copy it can read without a race. Tracing only --
+            /// m_session stays the authority.
+            std::atomic<SessionId> m_traceSession;
+
             std::atomic<bool> m_closed;
 
             net::Sender m_sender;

--- a/src/proto/IWorldGateway.h
+++ b/src/proto/IWorldGateway.h
@@ -177,6 +177,16 @@ namespace proto
                                      const std::shared_ptr<AuthContext>& context) = 0;
 
             /**
+             * @brief Record one packet in the packet dump, in either direction.
+             *
+             * `session` is INVALID_SESSION_ID for the pre-auth handshake only.
+             * Without it a dump cannot say which of several connected clients a
+             * packet belongs to, which is most of what a packet dump is for.
+             */
+            virtual void TracePacket(SessionId session, const WorldPacket& packet,
+                                     bool incoming) = 0;
+
+            /**
              * @brief Hand a decoded packet to an attached session.
              *
              * The protocol layer has already framed and decrypted it and knows

--- a/src/shared/Log/Log.cpp
+++ b/src/shared/Log/Log.cpp
@@ -1225,7 +1225,7 @@ void Log::outErrorScriptLib(const char* err, ...)
     }
 }
 
-void Log::outWorldPacketDump(uint32 socket, uint32 opcode, char const* opcodeName, ByteBuffer const* packet, bool incoming)
+void Log::outWorldPacketDump(uint32 session, uint32 opcode, char const* opcodeName, ByteBuffer const* packet, bool incoming)
 {
     if (!worldLogfile)
     {
@@ -1242,13 +1242,14 @@ void Log::outWorldPacketDump(uint32 socket, uint32 opcode, char const* opcodeNam
     std::string out;
     out.reserve(packet->size() * 3 + packet->size() / 16 + 128);
 
-    // header[512] is ample for the fixed text plus a (short, compile-time)
-    // opcode-name constant; snprintf is bounded, so output stays byte-identical
-    // to the previous fprintf for every real opcode name.
+    // SESSION, not SOCKET: the incoming side keyed this on the proto SessionId and the
+    // outgoing side on the account id, two numbering schemes in one field that named
+    // neither. header[512] is ample for the fixed text plus a (short, compile-time)
+    // opcode-name constant, and snprintf is bounded.
     char header[512];
-    snprintf(header, sizeof(header), "\n%s:\nSOCKET: %u\nLENGTH: %zu\nOPCODE: %s (0x%.4X)\nDATA:\n",
+    snprintf(header, sizeof(header), "\n%s:\nSESSION: %u\nLENGTH: %zu\nOPCODE: %s (0x%.4X)\nDATA:\n",
         incoming ? "CLIENT" : "SERVER",
-        socket, packet->size(), opcodeName, opcode);
+        session, packet->size(), opcodeName, opcode);
     out += header;
 
     char hexbuf[4];

--- a/src/shared/Log/Log.h
+++ b/src/shared/Log/Log.h
@@ -311,16 +311,16 @@ class Log : public MaNGOS::Singleton<Log>
         /**
          * @brief any log level
          *
-         * Called from WorldGateway::Deliver (incoming) and WorldSession::SendPacket
-         * (outgoing) -- see IsPacketLoggingEnabled()'s comment below.
+         * Called from WorldGateway::TracePacket, i.e. from ClientConnection on the
+         * network thread in both directions -- see IsPacketLoggingEnabled() below.
          *
-         * @param socket
+         * @param session which client stream the packet belongs to; 0 pre-auth
          * @param opcode
          * @param opcodeName
          * @param packet
          * @param incoming
          */
-        void outWorldPacketDump(uint32 socket, uint32 opcode, char const* opcodeName, ByteBuffer const* packet, bool incoming);
+        void outWorldPacketDump(uint32 session, uint32 opcode, char const* opcodeName, ByteBuffer const* packet, bool incoming);
         /**
          * @brief any log level
          *


### PR DESCRIPTION
The dump was taken in two places that keyed it on two different numbering schemes: WorldGateway::Deliver used the proto SessionId, WorldSession::SendPacket used the account id. Session 1 and account 1 both printed as "SOCKET: 1" and are not the same thing, so a log looked attributable while it was not -- and the field named neither.

Route both directions through IWorldGateway::TracePacket, called from ClientConnection, which is the one place that sees every packet on the wire. Print the SessionId as SESSION. The field is 0 only for the pre-auth handshake.

This also dumps what never reached WorldSession::SendPacket: SMSG_AUTH_CHALLENGE from onConnect and the SMSG_AUTH_RESPONSE that SendAuthStatus sends straight down the link. Nothing is lost the other way -- the only m_link->SendPacket call is the one WorldSession::SendPacket made immediately after the dump it used to take.

ClientConnection keeps an atomic copy of the id: SendPacket runs on the world thread while m_session is written on the network thread, so the trace needs a copy it can read without a race.

Brings the shape in line with mangos_zero and mangos_one, which already dump both directions from ClientConnection.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/257)
<!-- Reviewable:end -->
