### PR TITLE
Integration

### DIFF
--- a/src/game/ChatCommands/ReloadCommands.cpp
+++ b/src/game/ChatCommands/ReloadCommands.cpp
@@ -41,6 +41,7 @@
 #include "DisableMgr.h"
 #include "World.h"
 #include "MapManager.h"
+#include "GridMap.h"                                        // sTerrainMgr
 #include "CreatureEventAIMgr.h"
 #include "BattleGroundMgr.h"
 #include "SkillExtraItems.h"
@@ -1572,6 +1573,9 @@ bool ChatHandler::HandleReloadDisablesCommand(char* /*args*/)
     sLog.outString("Re-loading Disables...");
     DisableMgr::LoadDisables();
     DisableMgr::CheckQuestDisables();
+    // The collision rows are cached per map when its terrain is built, so a reload that
+    // stopped here would change the table and nothing else for every map in memory.
+    sTerrainMgr.RefreshCollisionDisables();
     SendGlobalSysMessage("DB table `disables` reloaded.", SEC_MODERATOR);
     return true;
 }

--- a/src/game/WorldHandlers/DisableMgr.cpp
+++ b/src/game/WorldHandlers/DisableMgr.cpp
@@ -498,6 +498,26 @@ bool IsVMAPDisabledFor(uint32 entry, uint8 flags)
 }
 
 /**
+ * @brief Every collision disable bit set for one map, or 0 when the map has none.
+ *
+ * Reads only. IsDisabledFor reaches m_DisableMap through operator[], which inserts a
+ * default-constructed entry when the type has no rows -- harmless from one thread and a
+ * data race from several, which is what a per-query call from every map-update thread
+ * would be. This walks the same container with find().
+ */
+uint8 GetCollisionDisablesFor(uint32 mapId)
+{
+    const DisableMap::const_iterator type = m_DisableMap.find(DISABLE_TYPE_VMAP);
+    if (type == m_DisableMap.end())
+    {
+        return 0;
+    }
+
+    const DisableTypeMap::const_iterator itr = type->second.find(mapId);
+    return itr == type->second.end() ? 0 : itr->second.flags;
+}
+
+/**
  * @brief Checks whether mmap pathfinding is enabled for a map.
  *
  * @param mapId The map identifier.

--- a/src/game/WorldHandlers/DisableMgr.h
+++ b/src/game/WorldHandlers/DisableMgr.h
@@ -76,6 +76,21 @@ namespace DisableMgr
     };
 
     bool IsVMAPDisabledFor(uint32 entry, uint8 flags);
+
+    /**
+     * @brief Every collision disable bit set for one map, or 0 for none.
+     *
+     * Asked ONCE per map, by TerrainInfo, and cached there -- the alternative is a map
+     * lookup inside every height, liquid and line-of-sight query, on every map-update
+     * thread. IsDisabledFor cannot serve that: it reaches the outer container through
+     * operator[], which INSERTS when the type is absent, so a lookup from a map thread
+     * is a write, and `.reload disables` clears the same container from the world
+     * thread. This one only reads.
+     *
+     * A reload therefore has to tell the caches: see TerrainManager::RefreshCollisionDisables.
+     */
+    uint8 GetCollisionDisablesFor(uint32 mapId);
+
     bool IsPathfindingEnabled(uint32 mapId);
 }
 

--- a/src/game/WorldHandlers/GridMap.cpp
+++ b/src/game/WorldHandlers/GridMap.cpp
@@ -179,17 +179,24 @@ bool TerrainInfo::Load(const uint32 x, const uint32 y)
         firstReference = (++m_GridRef[x][y] == 1);
     }
 
-    // Pins the cell's tile against the cache sweep for as long as a grid stands on it.
+    // Pins the cell's tile against the cache sweep for as long as a grid stands on it,
+    // and BY THE FIRST REFERENT ONLY, for the same reason the navmesh load below is:
+    // Unload releases on the last reference, so pinning per reference left the tile
+    // pinned N-1 times after N owners had all let go. The five-minute sweep then never
+    // evicts it, and resident terrain grows for the life of the process as instances
+    // are made and torn down. Pin and unpin must be counted the same way or neither
+    // count means anything.
+    //
     // The tile data itself still loads lazily, on the first query that reaches it.
-    m_terrain.PinCell(int(x), int(y));
-
-    // The navmesh tile is loaded by the FIRST referent only -- the refcount above is what
-    // makes several owners of one grid legal, and Unload already releases on the last.
-    // Loading unconditionally made every second owner ask for a tile the first had already
-    // brought in, which the mmap manager rejects and logs. Common now that a vessel is an
-    // active object holding grids a player then walks into.
     if (firstReference)
     {
+        m_terrain.PinCell(int(x), int(y));
+
+        // The navmesh tile is loaded by the FIRST referent only -- the refcount above is
+        // what makes several owners of one grid legal, and Unload already releases on the
+        // last. Loading unconditionally made every second owner ask for a tile the first
+        // had already brought in, which the mmap manager rejects and logs. Common now
+        // that a vessel is an active object holding grids a player then walks into.
         MMAP::MMapFactory::createOrGetMMapManager()->loadMap(m_mapId, x, y);
     }
     return true;

--- a/src/game/WorldHandlers/GridMap.cpp
+++ b/src/game/WorldHandlers/GridMap.cpp
@@ -56,6 +56,7 @@
 #include "DBCEnums.h"
 #include "DBCStores.h"
 #include "GridMap.h"
+#include "DisableMgr.h"
 #include "terrain/TileSerializer.hpp"
 #include "MoveMap.h"
 #include "World.h"
@@ -137,8 +138,11 @@ namespace
     }
 }
 
-TerrainInfo::TerrainInfo(uint32 mapid) : m_mapId(mapid), m_terrain(mapid), m_refMutex()
+TerrainInfo::TerrainInfo(uint32 mapid)
+    : m_collisionDisables(0), m_mapId(mapid), m_terrain(mapid), m_refMutex()
 {
+    RefreshCollisionDisables();
+
     for (int k = 0; k < MAX_NUMBER_OF_GRIDS; ++k)
     {
         for (int i = 0; i < MAX_NUMBER_OF_GRIDS; ++i)
@@ -149,6 +153,45 @@ TerrainInfo::TerrainInfo(uint32 mapid) : m_mapId(mapid), m_terrain(mapid), m_ref
 
     i_timer.SetInterval(60 * 1000);
     i_timer.SetCurrent(urand(20, 40) * 1000);
+}
+
+void TerrainInfo::RefreshCollisionDisables()
+{
+    m_collisionDisables.store(DisableMgr::GetCollisionDisablesFor(m_mapId),
+                              std::memory_order_relaxed);
+}
+
+/**
+ * @brief The engine-side source mask for this map's gathers.
+ *
+ * The `disables` table names what to switch OFF and the terrain engine takes what to
+ * gather, so the translation happens here -- the engine never learns that a database
+ * table exists, and this class never learns what a WMO is.
+ *
+ * The two collision flags mean what they did when this was a vmap: HEIGHT drops the
+ * baked model floors and leaves the ADT heightmap standing, LIQUIDSTATUS drops liquid
+ * authored inside a WMO and leaves the ADT's own. Runtime game-object geometry is not
+ * baked collision and is never dropped by either.
+ */
+uint32 TerrainInfo::SurfaceSources() const
+{
+    using namespace world::terrain;
+    const uint8 disabled = m_collisionDisables.load(std::memory_order_relaxed);
+    if (!disabled)
+    {
+        return FusedTerrain::SOURCE_ALL;
+    }
+
+    uint32 sources = FusedTerrain::SOURCE_ALL;
+    if (disabled & DisableMgr::COLLISION_DISABLE_HEIGHT)
+    {
+        sources &= ~uint32(FusedTerrain::SOURCE_STATIC);
+    }
+    if (disabled & DisableMgr::COLLISION_DISABLE_LIQUIDSTATUS)
+    {
+        sources &= ~uint32(FusedTerrain::SOURCE_STATIC_LIQUID);
+    }
+    return sources;
 }
 
 TerrainInfo::~TerrainInfo()
@@ -244,7 +287,7 @@ world::terrain::Column TerrainInfo::ColumnAt(float x, float y, float zTop, float
                                              const world::terrain::ILiveGeometry* live,
                                              uint32 phasemask) const
 {
-    return m_terrain.ColumnAt(x, y, zTop, zBottom, live, phasemask);
+    return m_terrain.ColumnAt(x, y, zTop, zBottom, live, phasemask, SurfaceSources());
 }
 
 std::optional<float> TerrainInfo::StaticFloor(float x, float y, float z) const
@@ -256,6 +299,14 @@ std::optional<float> TerrainInfo::StaticFloor(float x, float y, float z) const
 bool TerrainInfo::GetAreaInfo(float x, float y, float z, uint32& flags, int32& adtId,
                               int32& rootId, int32& groupId) const
 {
+    // No answer rather than a wrong one: the caller reads false as "no WMO here", which
+    // is what a map with its baked area lookup switched off is asserting.
+    if (m_collisionDisables.load(std::memory_order_relaxed) &
+        DisableMgr::COLLISION_DISABLE_AREAFLAG)
+    {
+        return false;
+    }
+
     float groundZ = 0.0f;
     return m_terrain.GetAreaInfo(x, y, z, flags, adtId, rootId, groupId, groundZ);
 }
@@ -504,12 +555,32 @@ float TerrainInfo::GetWaterOrGroundLevel(float x, float y, float z, float* pGrou
 bool TerrainInfo::IsInLineOfSight(float x1, float y1, float z1, float x2, float y2,
                                   float z2) const
 {
+    // BAKED collision only. A map with line of sight switched off still has doors and
+    // lifts, and Map::IsInLineOfSight asks the dynamic tree separately -- that is the
+    // same split the vmap flag always meant, and the reason it is answered here rather
+    // than at the Map.
+    if (m_collisionDisables.load(std::memory_order_relaxed) &
+        DisableMgr::COLLISION_DISABLE_LOS)
+    {
+        return true;
+    }
+
     return m_terrain.IsInLineOfSight(x1, y1, z1, x2, y2, z2);
 }
 
 float TerrainInfo::NearestHitFraction(float x1, float y1, float z1, float x2, float y2,
                                       float z2) const
 {
+    // The same answer as IsInLineOfSight above, in the units Map uses to race the static
+    // and dynamic worlds against each other: nothing baked blocks, so the static side
+    // never wins. Leaving this one out would have made a disabled map report clear sight
+    // and still stop a spell at the wall it just said was not there.
+    if (m_collisionDisables.load(std::memory_order_relaxed) &
+        DisableMgr::COLLISION_DISABLE_LOS)
+    {
+        return 2.0f;
+    }
+
     return m_terrain.NearestHitFraction(x1, y1, z1, x2, y2, z2);
 }
 
@@ -522,6 +593,24 @@ TerrainManager::~TerrainManager()
     for (TerrainDataMap::iterator it = i_TerrainMap.begin(); it != i_TerrainMap.end(); ++it)
     {
         delete it->second;
+    }
+}
+
+/**
+ * @brief Re-reads `disables` into every terrain already built.
+ *
+ * A terrain reads its row once, when it is created, because the answer sits on the
+ * hottest query path in the server. That makes a reload of the table a no-op for every
+ * map already in memory unless it is pushed -- which is the failure this exists to
+ * prevent, and the reason it is called by the reload command and not only at start-up.
+ */
+void TerrainManager::RefreshCollisionDisables()
+{
+    std::lock_guard<LOCK_TYPE> _guard(m_mutex);
+
+    for (TerrainDataMap::const_iterator it = i_TerrainMap.begin(); it != i_TerrainMap.end(); ++it)
+    {
+        it->second->RefreshCollisionDisables();
     }
 }
 

--- a/src/game/WorldHandlers/GridMap.h
+++ b/src/game/WorldHandlers/GridMap.h
@@ -231,6 +231,12 @@ class TerrainInfo : public Referencable<AtomicLong>
         // Ages the tile cache and reclaims what no active grid holds.
         void CleanUpGrids(const uint32 diff);
 
+        /// Re-reads this map's row from `disables`. Called once when the terrain is
+        /// created and again after `.reload disables`, because the answer is cached:
+        /// asking DisableMgr inside every height and sight query would put a container
+        /// lookup on the hottest path in the server, from every map-update thread.
+        void RefreshCollisionDisables();
+
     protected:
         friend class Map;
         bool Load(const uint32 x, const uint32 y);
@@ -239,6 +245,16 @@ class TerrainInfo : public Referencable<AtomicLong>
     private:
         TerrainInfo(const TerrainInfo&);
         TerrainInfo& operator=(const TerrainInfo&);
+
+        /// Which of this map's collision answers the `disables` table has switched off.
+        /// Atomic because a reload writes it from the world thread while map-update
+        /// threads read it; a stale read for one tick is the whole cost of not locking,
+        /// and the value is one byte that is never half-written.
+        std::atomic<uint8> m_collisionDisables;
+
+        /// The engine-side source mask this map's queries gather with, derived from
+        /// m_collisionDisables. The terrain engine knows nothing about `disables`.
+        uint32 SurfaceSources() const;
 
         const uint32 m_mapId;
 
@@ -265,6 +281,11 @@ class TerrainManager : public MaNGOS::Singleton<TerrainManager>
 
         void Update(const uint32 diff);
         void UnloadAll();
+
+        /// Pushes the `disables` table into every terrain already built. The rows are
+        /// read once per map and cached there, so a reload that does not do this leaves
+        /// the old answer in place for the life of the process.
+        void RefreshCollisionDisables();
 
         uint16 GetAreaFlag(uint32 mapid, float x, float y, float z) const
         {

--- a/src/game/WorldHandlers/MoveMapSharedDefines.h
+++ b/src/game/WorldHandlers/MoveMapSharedDefines.h
@@ -33,7 +33,13 @@
 
 #define MMAP_MAGIC 0x4d4d4150   // 'MMAP'
 // Version 6 adds orthogonal terrain/liquid border cells during fused navmesh baking.
-#define MMAP_VERSION 6
+// Version 7 stores the TERRAIN BIT in each polygon's flags instead of a bare 1. Detour
+// filters on flags, never on the area id, so a version 6 tile tells every query that
+// every polygon is ground: a swimmer's WATER|MAGMA|SLIME mask matches nothing and a
+// walker is cleared to cross magma. The two are indistinguishable at load time -- both
+// are "a poly with flags set" -- so the version is what makes a stale bake say so
+// instead of pathing wrongly for as long as it stays on disk.
+#define MMAP_VERSION 7
 
 struct MmapTileHeader
 {

--- a/src/game/WorldHandlers/World.cpp
+++ b/src/game/WorldHandlers/World.cpp
@@ -79,6 +79,7 @@
 #include "LootMgr.h"
 #include "ItemEnchantmentMgr.h"
 #include "MapManager.h"
+#include "DataIntegrity/DataManifest.h"
 #include "ScriptMgr.h"
 #include "CreatureAIRegistry.h"
 #include "ProgressBar.h"
@@ -339,6 +340,83 @@ World::AddSession_(WorldSession* s)
 
 
 
+/**
+ * @brief Re-hashes the baked data set against the manifest the extractor wrote.
+ *
+ * A tile carries a format version, so a bake from an older extractor is refused on
+ * sight. Everything else that can be wrong with a data set looks perfectly valid: a file
+ * truncated by a full disk or an interrupted copy, a map whose tiles came half from one
+ * bake and half from another, a stale file an older run left behind, a sector that
+ * rotted. Each of those loads, answers wrongly in one corner of one map, and is
+ * indistinguishable from a bug in the server.
+ *
+ * DataIntegrityCheck: 0 skips this, 1 reports, 2 refuses to start. Reporting is the
+ * default because the cost is a few seconds of hashing at start-up, once, spread over
+ * every core -- and because the alternative to knowing is not knowing.
+ *
+ * A data set with no manifest is NOT an error. It was baked before this existed, or by
+ * hand; saying so once is honest, refusing to start over it would not be.
+ */
+void World::VerifyDataIntegrity()
+{
+    namespace di = MaNGOS::DataIntegrity;
+
+    const uint32 mode = getConfig(CONFIG_UINT32_DATA_INTEGRITY_CHECK);
+    if (mode == 0)
+    {
+        return;
+    }
+
+    sLog.outString("Verifying baked data against %s...", di::MANIFEST_FILE_NAME);
+
+    const uint32 started = getMSTime();
+    const di::VerifyResult result = di::VerifyManifest(m_dataPath);
+    const uint32 tookMs = getMSTimeDiff(started, getMSTime());
+
+    if (!result.manifestFound)
+    {
+        sLog.outString(">> No %s in '%s'; the data set is unverified. Re-run "
+                       "mangos-extractor to create one.",
+                       di::MANIFEST_FILE_NAME, m_dataPath.c_str());
+        return;
+    }
+
+    if (!result.manifestReadable)
+    {
+        sLog.outError("%s in '%s' could not be parsed. Re-run mangos-extractor.",
+                      di::MANIFEST_FILE_NAME, m_dataPath.c_str());
+        if (mode >= 2)
+        {
+            Log::WaitBeforeContinueIfNeed();
+            exit(1);
+        }
+        return;
+    }
+
+    if (result.Ok())
+    {
+        sLog.outString(">> %zu file(s) verified in %u ms", result.verified, tookMs);
+        return;
+    }
+
+    sLog.outError("BAKED DATA DOES NOT MATCH %s: %zu changed, %zu missing, %zu unreadable "
+                  "of %zu listed (%u ms).",
+                  di::MANIFEST_FILE_NAME, result.changed, result.missing,
+                  result.unreadable, result.listed, tookMs);
+    for (const std::string& example : result.examples)
+    {
+        sLog.outError("  %s", example.c_str());
+    }
+    sLog.outError("Re-run mangos-extractor against the client. A file that is present "
+                  "but does not match is read as valid and answers wrongly.");
+
+    if (mode >= 2)
+    {
+        Log::WaitBeforeContinueIfNeed();
+        exit(1);
+    }
+}
+
 /// Initialize the World
 void World::SetInitialWorldSettings()
 {
@@ -378,6 +456,10 @@ void World::SetInitialWorldSettings()
         Log::WaitBeforeContinueIfNeed();
         exit(1);
     }
+
+    ///- The tiles exist. Whether they are the ones the extractor wrote is a different
+    ///  question, and the one that produces the bug reports nobody can reproduce.
+    VerifyDataIntegrity();
 
     ///- Loading strings. Getting no records means core load has to be canceled because no error message can be output.
     sLog.outString("Loading MaNGOS strings...");

--- a/src/game/WorldHandlers/World.cpp
+++ b/src/game/WorldHandlers/World.cpp
@@ -488,6 +488,9 @@ void World::SetInitialWorldSettings()
 
     sLog.outString("Loading Disables...");                  // must be before loading quests and items
     DisableMgr::LoadDisables();
+    // Order-independent rather than order-dependent: a terrain reads its collision row
+    // when it is built, and nothing here promises no map was touched before this line.
+    sTerrainMgr.RefreshCollisionDisables();
 
     sLog.outString("Loading Item Templates...");            // must be after LoadRandomEnchantmentsTable and LoadPageTexts
     sObjectMgr.LoadItemPrototypes();

--- a/src/game/WorldHandlers/World.h
+++ b/src/game/WorldHandlers/World.h
@@ -238,6 +238,8 @@ enum eConfigUInt32Values
     CONFIG_UINT32_CINEMATIC_FLYOVER_UPDATE_INTERVAL_MS,
     CONFIG_UINT32_CINEMATIC_FLYOVER_TIMEOUT_SEC,
     CONFIG_UINT32_CINEMATIC_FLYOVER_BODY_ENTRY,
+    /// 0 off, 1 report, 2 refuse to start. See World::VerifyDataIntegrity.
+    CONFIG_UINT32_DATA_INTEGRITY_CHECK,
     CONFIG_UINT32_VALUE_COUNT
 };
 
@@ -597,6 +599,10 @@ class World
 
         void SetInitialWorldSettings();
         void LoadConfigSettings(bool reload = false);
+
+        /// Re-hashes the baked data set against the manifest the extractor wrote.
+        /// Governed by DataIntegrityCheck; exits when that says 2 and the check fails.
+        void VerifyDataIntegrity();
 
         void SendWorldText(int32 string_id, ...);
         void SendGlobalMessage(WorldPacket* packet, AccountTypes minSec = SEC_PLAYER);

--- a/src/game/WorldHandlers/WorldConfig.cpp
+++ b/src/game/WorldHandlers/WorldConfig.cpp
@@ -637,6 +637,12 @@ void World::LoadConfigSettings(bool reload)
     setConfigMinMax(CONFIG_UINT32_CINEMATIC_FLYOVER_TIMEOUT_SEC, "CinematicFlyover.TimeoutSec", 120, 1, 600);
     setConfig(CONFIG_UINT32_CINEMATIC_FLYOVER_BODY_ENTRY, "CinematicFlyover.BodyEntry", 12999);
 
+    ///- How hard to check the baked data set against the manifest the extractor wrote.
+    ///  1 (report) by default: the check is what turns "one corner of one map behaves
+    ///  oddly" into a line naming the file, and a server whose data is intact pays a few
+    ///  seconds of hashing once, at start-up, on every core it has.
+    setConfigMinMax(CONFIG_UINT32_DATA_INTEGRITY_CHECK, "DataIntegrityCheck", 1, 0, 2);
+
     ///- Load the CharDelete related config options
     setConfigMinMax(CONFIG_UINT32_CHARDELETE_METHOD, "CharDelete.Method", 0, 0, 1);
     setConfigMinMax(CONFIG_UINT32_CHARDELETE_MIN_LEVEL, "CharDelete.MinLevel", 0, 0, getConfig(CONFIG_UINT32_MAX_PLAYER_LEVEL));

--- a/src/mangosd/mangosd.conf.dist.in
+++ b/src/mangosd/mangosd.conf.dist.in
@@ -59,10 +59,26 @@ ConfVersion=@MANGOS_WORLD_VER@
 #        on different IP addresses using default ports.
 #        DO NOT CHANGE THIS UNLESS YOU _REALLY_ KNOW WHAT YOU'RE DOING
 #
+#    DataIntegrityCheck
+#        Re-hash the baked data set under DataDir against data.manifest, the SHA-256
+#        listing mangos-extractor writes at the end of a successful bake.
+#        A tile carries a format version, so an old bake is refused on sight. This
+#        catches what a version cannot: a file truncated by a full disk or an
+#        interrupted copy, a map whose tiles came half from one bake and half from
+#        another, a stale file an older run left behind, a sector that rotted. Each of
+#        those loads as a valid tile and answers wrongly in one corner of one map.
+#        Costs a few seconds at start-up, once, spread over every core. A data set with
+#        no manifest is reported and accepted, never refused.
+#        Checkable by hand:  cd <DataDir> && sha256sum -c data.manifest
+#        0 - off
+#        1 - report a mismatch and start anyway (default)
+#        2 - refuse to start
+#
 ################################################################################
 
 RealmID                      = 1
 DataDir                      = "@CONF_INSTALL_DIR@"
+DataIntegrityCheck           = 1
 LogsDir                      = ""
 LoginDatabaseInfo            = "127.0.0.1;3306;root;mangos;realmd"
 WorldDatabaseInfo            = "127.0.0.1;3306;root;mangos;mangos2"

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -237,6 +237,39 @@ configure_file(SystemConfig.h.in ${CMAKE_CURRENT_BINARY_DIR}/SystemConfig.h)
 
 TEST_BIG_ENDIAN(ENDIAN_VALUE)
 
+# =============================================================================
+# dataintegrity -- the SHA-256 manifest, as a library of its own.
+#
+# Not part of `shared`, on purpose. The baker has to WRITE the manifest the server
+# READS, and `shared` exports MySQL as a PUBLIC dependency; linking it into the
+# extractor to reach two files would drag a database client into a tool that has never
+# needed one. This target carries OpenSSL and nothing else -- and OpenSSL is already
+# mandatory for the whole project, so it adds no requirement to either side.
+#
+# One implementation, both consumers: the format cannot drift from itself.
+# =============================================================================
+add_library(dataintegrity STATIC
+    DataIntegrity/DataManifest.cpp
+    DataIntegrity/DataManifest.h
+    DataIntegrity/Sha256.cpp
+    DataIntegrity/Sha256.h
+)
+
+target_include_directories(dataintegrity
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(dataintegrity
+    PUBLIC
+        Threads::Threads
+    PRIVATE
+        mangos_openssl
+        mangos_openssl_strict
+)
+
+set_target_properties(dataintegrity PROPERTIES FOLDER "shared")
+
 add_library(shared STATIC
     ${SRC_GRP_AUTH}
     ${SRC_GRP_COMMON}
@@ -287,6 +320,7 @@ target_link_libraries(shared
         Threads::Threads
         utf8
         MySQL::MySQL
+        dataintegrity
         ${CMAKE_DL_LIBS}
         mangos_openssl
         $<$<BOOL:${WIN32}>:dbghelp>

--- a/src/shared/DataIntegrity/DataManifest.cpp
+++ b/src/shared/DataIntegrity/DataManifest.cpp
@@ -1,0 +1,377 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "DataIntegrity/DataManifest.h"
+#include "DataIntegrity/Sha256.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <system_error>
+#include <thread>
+
+namespace MaNGOS
+{
+    namespace DataIntegrity
+    {
+        const char* const MANIFEST_FILE_NAME = "data.manifest";
+
+        namespace
+        {
+            constexpr std::size_t MAX_EXAMPLES = 8;
+            constexpr std::size_t HEX_LENGTH = 64;
+
+            std::string JoinPath(const std::string& a, const std::string& b)
+            {
+                if (a.empty())
+                {
+                    return b;
+                }
+                if (b.empty())
+                {
+                    return a;
+                }
+                const char last = a[a.size() - 1];
+                return (last == '/' || last == '\\') ? a + b : a + "/" + b;
+            }
+
+            /// Always '/', on every platform. The manifest travels with the data set:
+            /// a bake done on Windows must verify on the Linux box it is copied to, and
+            /// a path separator is not a property of the bytes being described.
+            std::string ToPortablePath(const std::filesystem::path& relative)
+            {
+                std::string s = relative.generic_string();
+                return s;
+            }
+
+            /// Sorted so two bakes of the same data produce byte-identical manifests --
+            /// which is what lets one be diffed against another, and what stops a
+            /// directory iteration order from looking like a change.
+            void SortEntries(std::vector<ManifestEntry>& entries)
+            {
+                std::sort(entries.begin(), entries.end(),
+                          [](const ManifestEntry& a, const ManifestEntry& b)
+                          {
+                              return a.path < b.path;
+                          });
+            }
+
+            bool CollectFiles(const std::string& root, const std::string& subdir,
+                              std::vector<std::string>& out)
+            {
+                std::error_code ec;
+                const std::filesystem::path base = std::filesystem::path(root) / subdir;
+                if (!std::filesystem::exists(base, ec))
+                {
+                    // A data set without a navmesh is a data set without a navmesh, not
+                    // a broken one; the caller lists what it hopes for, not what it
+                    // requires.
+                    return true;
+                }
+
+                std::filesystem::recursive_directory_iterator it(
+                    base, std::filesystem::directory_options::skip_permission_denied, ec);
+                if (ec)
+                {
+                    return false;
+                }
+
+                const std::filesystem::path rootPath(root);
+                for (const auto& entry : it)
+                {
+                    if (ec)
+                    {
+                        return false;
+                    }
+                    if (!entry.is_regular_file(ec) || ec)
+                    {
+                        continue;
+                    }
+                    const std::filesystem::path rel =
+                        std::filesystem::relative(entry.path(), rootPath, ec);
+                    if (ec)
+                    {
+                        return false;
+                    }
+                    out.push_back(ToPortablePath(rel));
+                }
+                return true;
+            }
+
+            /// Hashes `paths` across `threads` workers, writing digests into `digests`
+            /// by index. Empty string means the file could not be read.
+            void HashAll(const std::string& root, const std::vector<std::string>& paths,
+                         std::vector<std::string>& digests, unsigned threads,
+                         const ProgressFn& progress)
+            {
+                digests.assign(paths.size(), std::string());
+                if (paths.empty())
+                {
+                    return;
+                }
+
+                if (threads == 0)
+                {
+                    threads = std::thread::hardware_concurrency();
+                }
+                threads = std::max(1u, std::min<unsigned>(threads, 16u));
+                threads = unsigned(std::min<std::size_t>(threads, paths.size()));
+
+                std::atomic<std::size_t> next{0};
+                std::atomic<std::size_t> done{0};
+                std::mutex progressMutex;
+
+                const auto worker = [&]()
+                {
+                    for (;;)
+                    {
+                        const std::size_t i = next.fetch_add(1, std::memory_order_relaxed);
+                        if (i >= paths.size())
+                        {
+                            return;
+                        }
+
+                        if (auto hex = Sha256File(JoinPath(root, paths[i])))
+                        {
+                            digests[i] = *hex;
+                        }
+
+                        const std::size_t n = done.fetch_add(1, std::memory_order_relaxed) + 1;
+                        if (progress)
+                        {
+                            // Serialised: the callback writes to the console, and the
+                            // whole point of hashing in parallel is not to interleave
+                            // the output of it.
+                            std::lock_guard<std::mutex> lock(progressMutex);
+                            progress(n, paths.size(), paths[i]);
+                        }
+                    }
+                };
+
+                std::vector<std::thread> pool;
+                pool.reserve(threads - 1);
+                for (unsigned t = 1; t < threads; ++t)
+                {
+                    pool.emplace_back(worker);
+                }
+                worker();
+                for (std::thread& t : pool)
+                {
+                    t.join();
+                }
+            }
+        }
+
+        bool ReadManifest(const std::string& manifestPath,
+                          std::vector<ManifestEntry>& out)
+        {
+            std::ifstream in(manifestPath, std::ios::binary);
+            if (!in.good())
+            {
+                return false;
+            }
+
+            std::string line;
+            while (std::getline(in, line))
+            {
+                // Tolerate CRLF: the manifest is written LF, but it travels with the
+                // data set and a Windows editor or an archiver may have been over it.
+                while (!line.empty() && (line.back() == '\r' || line.back() == '\n'))
+                {
+                    line.pop_back();
+                }
+                if (line.empty())
+                {
+                    continue;
+                }
+
+                // `<64 hex><two spaces><path>` -- the sha256sum layout, and anything
+                // else is a line this did not write.
+                if (line.size() < HEX_LENGTH + 3 || line[HEX_LENGTH] != ' ' ||
+                    line[HEX_LENGTH + 1] != ' ')
+                {
+                    return false;
+                }
+
+                ManifestEntry entry;
+                entry.sha256 = line.substr(0, HEX_LENGTH);
+                if (entry.sha256.find_first_not_of("0123456789abcdef") != std::string::npos)
+                {
+                    return false;
+                }
+                entry.path = line.substr(HEX_LENGTH + 2);
+                if (entry.path.empty())
+                {
+                    return false;
+                }
+                out.push_back(std::move(entry));
+            }
+
+            return true;
+        }
+
+        bool WriteManifest(const std::string& root,
+                           const std::vector<std::string>& subdirs,
+                           const ProgressFn& progress)
+        {
+            std::vector<std::string> paths;
+            for (const std::string& subdir : subdirs)
+            {
+                if (!CollectFiles(root, subdir, paths))
+                {
+                    return false;
+                }
+            }
+
+            // The manifest itself is never in its own manifest.
+            paths.erase(std::remove(paths.begin(), paths.end(),
+                                    std::string(MANIFEST_FILE_NAME)),
+                        paths.end());
+            std::sort(paths.begin(), paths.end());
+
+            std::vector<std::string> digests;
+            HashAll(root, paths, digests, 0, progress);
+
+            std::vector<ManifestEntry> entries;
+            entries.reserve(paths.size());
+            for (std::size_t i = 0; i < paths.size(); ++i)
+            {
+                if (digests[i].empty())
+                {
+                    // A manifest listing only what could be read certifies the gaps.
+                    return false;
+                }
+                entries.push_back(ManifestEntry{paths[i], digests[i]});
+            }
+            SortEntries(entries);
+
+            // Written aside and renamed over: a manifest interrupted half way is worse
+            // than no manifest at all, because the server would believe it and report
+            // every unwritten file as missing.
+            const std::string finalPath = JoinPath(root, MANIFEST_FILE_NAME);
+            const std::string tempPath = finalPath + ".part";
+
+            {
+                std::ofstream out(tempPath, std::ios::binary | std::ios::trunc);
+                if (!out.good())
+                {
+                    return false;
+                }
+                for (const ManifestEntry& e : entries)
+                {
+                    // '\n' with a binary stream on purpose: the file must be LF on every
+                    // platform or the same data set hashes to two different manifests.
+                    out << e.sha256 << "  " << e.path << '\n';
+                }
+                out.flush();
+                if (!out.good())
+                {
+                    return false;
+                }
+            }
+
+            std::error_code ec;
+            std::filesystem::rename(tempPath, finalPath, ec);
+            if (ec)
+            {
+                // Windows will not rename over an existing file on every filesystem.
+                std::filesystem::remove(finalPath, ec);
+                ec.clear();
+                std::filesystem::rename(tempPath, finalPath, ec);
+            }
+            if (ec)
+            {
+                std::filesystem::remove(tempPath, ec);
+                return false;
+            }
+            return true;
+        }
+
+        VerifyResult VerifyManifest(const std::string& root, unsigned threads,
+                                    const ProgressFn& progress)
+        {
+            VerifyResult result;
+
+            const std::string manifestPath = JoinPath(root, MANIFEST_FILE_NAME);
+            std::error_code ec;
+            if (!std::filesystem::exists(manifestPath, ec))
+            {
+                return result;
+            }
+            result.manifestFound = true;
+
+            std::vector<ManifestEntry> entries;
+            if (!ReadManifest(manifestPath, entries))
+            {
+                return result;
+            }
+            result.manifestReadable = true;
+            result.listed = entries.size();
+
+            std::vector<std::string> paths;
+            paths.reserve(entries.size());
+            for (const ManifestEntry& e : entries)
+            {
+                paths.push_back(e.path);
+            }
+
+            std::vector<std::string> digests;
+            HashAll(root, paths, digests, threads, progress);
+
+            for (std::size_t i = 0; i < entries.size(); ++i)
+            {
+                if (!digests[i].empty())
+                {
+                    if (digests[i] == entries[i].sha256)
+                    {
+                        ++result.verified;
+                        continue;
+                    }
+                    ++result.changed;
+                }
+                else if (std::filesystem::exists(JoinPath(root, entries[i].path), ec))
+                {
+                    // Present but unreadable is its own answer: a permission problem or
+                    // a failing disk is not the same report as a file somebody deleted.
+                    ++result.unreadable;
+                }
+                else
+                {
+                    ++result.missing;
+                }
+
+                if (result.examples.size() < MAX_EXAMPLES)
+                {
+                    result.examples.push_back(entries[i].path);
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/shared/DataIntegrity/DataManifest.h
+++ b/src/shared/DataIntegrity/DataManifest.h
@@ -1,0 +1,131 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_DATAMANIFEST_H
+#define MANGOS_DATAMANIFEST_H
+
+// WHAT THE BAKER WROTE, so the server can tell whether that is what it is reading.
+//
+// A tile carries a format version, which catches a bake from an older extractor. It
+// cannot catch anything else: a tile truncated by a full disk or an interrupted copy, a
+// map whose tiles came half from one bake and half from another, a stale file an older
+// run left behind, or a sector that rotted. Every one of those loads as a well-formed
+// tile of the right version and answers wrongly, or answers nothing, in one corner of
+// one map -- which is exactly the failure nobody can reproduce.
+//
+// So the baker records a SHA-256 per file and the server checks them at start-up.
+//
+// FORMAT. One line per file, `<64 hex>  <path relative to the data directory>`, two
+// spaces between, sorted by path, LF endings. That is deliberately the layout
+// `sha256sum -c` reads, so an administrator can verify a data set with a tool that was
+// not written here and does not have to be trusted:
+//
+//     cd <DataDir> && sha256sum -c data.manifest
+//
+// There is no header line and no version field, because a comment would break that
+// property. The manifest is identified by its NAME and its location, and every file it
+// covers carries its own format version inside it.
+//
+// NOT AUTHENTICATION. The manifest sits beside the files it describes, so whoever can
+// replace a tile can replace the line about it. This detects damage, not an attacker.
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace MaNGOS
+{
+    namespace DataIntegrity
+    {
+        /// The manifest's file name, inside the data directory.
+        extern const char* const MANIFEST_FILE_NAME;
+
+        struct ManifestEntry
+        {
+            std::string path;       ///< relative to the data directory, '/' separated
+            std::string sha256;     ///< 64 lower-case hex characters
+        };
+
+        /// Reports a file just finished. `done` counts files, not bytes.
+        using ProgressFn = std::function<void(std::size_t done, std::size_t total,
+                                              const std::string& path)>;
+
+        /**
+         * @brief Hash every file under @p subdirs of @p root and write the manifest.
+         *
+         * Writes to a temporary name and renames over the target, so a manifest never
+         * exists in a half-written state -- which would be worse than none at all, since
+         * the server would read it and report failures for files that are perfectly good.
+         *
+         * @return false if a directory could not be walked, a file could not be hashed,
+         *         or the write failed. A manifest that lists only what it managed to
+         *         read certifies the gaps.
+         */
+        bool WriteManifest(const std::string& root,
+                           const std::vector<std::string>& subdirs,
+                           const ProgressFn& progress = nullptr);
+
+        struct VerifyResult
+        {
+            bool manifestFound = false;
+            bool manifestReadable = false;
+            std::size_t listed = 0;         ///< entries in the manifest
+            std::size_t verified = 0;       ///< present and matching
+            std::size_t missing = 0;        ///< listed but not on disk
+            std::size_t changed = 0;        ///< present with a different digest
+            std::size_t unreadable = 0;     ///< present but could not be read
+            /// The first few offending paths, for a log line that names something.
+            std::vector<std::string> examples;
+
+            bool Ok() const
+            {
+                return manifestFound && manifestReadable && !missing && !changed &&
+                       !unreadable;
+            }
+        };
+
+        /**
+         * @brief Re-hash everything the manifest lists and compare.
+         *
+         * @param threads how many files to hash at once; 0 asks the hardware. This is a
+         *        gigabyte or two of reading at start-up, and it is embarrassingly
+         *        parallel -- one file per worker, no shared state but the index.
+         *
+         * A file present on disk and NOT listed is not an error: a data directory holds
+         * things the baker did not write (configs, a second realm's copy), and treating
+         * those as corruption would make the check useless in exactly the deployments
+         * that need it.
+         */
+        VerifyResult VerifyManifest(const std::string& root, unsigned threads = 0,
+                                    const ProgressFn& progress = nullptr);
+
+        /// Parses a manifest file. Exposed for the tests and for tooling.
+        bool ReadManifest(const std::string& manifestPath,
+                          std::vector<ManifestEntry>& out);
+    }
+}
+
+#endif

--- a/src/shared/DataIntegrity/Sha256.cpp
+++ b/src/shared/DataIntegrity/Sha256.cpp
@@ -1,0 +1,145 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "DataIntegrity/Sha256.h"
+
+#include <openssl/evp.h>
+
+#include <array>
+#include <cstdio>
+#include <memory>
+#include <vector>
+
+namespace MaNGOS
+{
+    namespace DataIntegrity
+    {
+        namespace
+        {
+            /// 64 KiB. Large enough that the syscall is not the cost and small enough
+            /// that hashing a thousand files never holds a megabyte per worker.
+            constexpr std::size_t READ_BLOCK = 64 * 1024;
+
+            struct EvpDeleter
+            {
+                void operator()(EVP_MD_CTX* ctx) const { EVP_MD_CTX_free(ctx); }
+            };
+
+            using EvpCtx = std::unique_ptr<EVP_MD_CTX, EvpDeleter>;
+
+            std::string ToHex(const unsigned char* digest, unsigned int length)
+            {
+                static const char* kDigits = "0123456789abcdef";
+                std::string out;
+                out.reserve(std::size_t(length) * 2);
+                for (unsigned int i = 0; i < length; ++i)
+                {
+                    out.push_back(kDigits[digest[i] >> 4]);
+                    out.push_back(kDigits[digest[i] & 0x0F]);
+                }
+                return out;
+            }
+        }
+
+        std::string Sha256Hex(const void* data, std::size_t length)
+        {
+            EvpCtx ctx(EVP_MD_CTX_new());
+            if (!ctx)
+            {
+                return std::string();
+            }
+
+            if (EVP_DigestInit_ex(ctx.get(), EVP_sha256(), nullptr) != 1)
+            {
+                return std::string();
+            }
+
+            // A null pointer with a zero length is the empty message, which has a
+            // perfectly good digest; passing null to EVP_DigestUpdate is not defined.
+            if (length && EVP_DigestUpdate(ctx.get(), data, length) != 1)
+            {
+                return std::string();
+            }
+
+            std::array<unsigned char, EVP_MAX_MD_SIZE> digest{};
+            unsigned int digestLength = 0;
+            if (EVP_DigestFinal_ex(ctx.get(), digest.data(), &digestLength) != 1)
+            {
+                return std::string();
+            }
+
+            return ToHex(digest.data(), digestLength);
+        }
+
+        std::optional<std::string> Sha256File(const std::string& path)
+        {
+            std::FILE* f = std::fopen(path.c_str(), "rb");
+            if (!f)
+            {
+                return std::nullopt;
+            }
+
+            EvpCtx ctx(EVP_MD_CTX_new());
+            if (!ctx || EVP_DigestInit_ex(ctx.get(), EVP_sha256(), nullptr) != 1)
+            {
+                std::fclose(f);
+                return std::nullopt;
+            }
+
+            std::vector<unsigned char> block(READ_BLOCK);
+            for (;;)
+            {
+                const std::size_t got = std::fread(block.data(), 1, block.size(), f);
+                if (got && EVP_DigestUpdate(ctx.get(), block.data(), got) != 1)
+                {
+                    std::fclose(f);
+                    return std::nullopt;
+                }
+                if (got < block.size())
+                {
+                    // A short read is the end of the file OR an I/O error, and the two
+                    // must not produce the same answer: hashing what was read up to a
+                    // failed sector yields a digest for bytes nobody has.
+                    const bool failed = std::ferror(f) != 0;
+                    std::fclose(f);
+                    if (failed)
+                    {
+                        return std::nullopt;
+                    }
+                    break;
+                }
+            }
+
+            std::array<unsigned char, EVP_MAX_MD_SIZE> digest{};
+            unsigned int digestLength = 0;
+            if (EVP_DigestFinal_ex(ctx.get(), digest.data(), &digestLength) != 1)
+            {
+                return std::nullopt;
+            }
+
+            return ToHex(digest.data(), digestLength);
+        }
+    }
+}

--- a/src/shared/DataIntegrity/Sha256.h
+++ b/src/shared/DataIntegrity/Sha256.h
@@ -1,0 +1,57 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_SHA256_H
+#define MANGOS_SHA256_H
+
+// SHA-256 over bytes and over whole files, as lower-case hex.
+//
+// OpenSSL's EVP rather than a vendored implementation: the project already requires
+// OpenSSL 3.x, and the one thing a hand-written hash buys -- a baker with no dependency
+// -- is not worth owning a primitive whose failure mode is a digest that looks fine.
+//
+// This is INTEGRITY, not authentication. It answers "are these the bytes the baker
+// wrote", which catches a truncated copy, a half-finished download, a stale tile left
+// behind by an older bake, and a disk that flipped a sector. It does not answer "did an
+// attacker replace them", because a manifest sitting beside the files it describes can
+// be rewritten by anyone who can rewrite the files.
+
+#include <cstddef>
+#include <optional>
+#include <string>
+
+namespace MaNGOS
+{
+    namespace DataIntegrity
+    {
+        /// 64 lower-case hex characters, or empty when OpenSSL refuses.
+        std::string Sha256Hex(const void* data, std::size_t length);
+
+        /// Reads the file in blocks; nothing when it cannot be opened or read whole.
+        std::optional<std::string> Sha256File(const std::string& path);
+    }
+}
+
+#endif

--- a/src/shared/Geometry/GeometryMath.h
+++ b/src/shared/Geometry/GeometryMath.h
@@ -59,14 +59,27 @@ namespace Geometry
     }
 
     /// Wraps t into the half-open interval [lo, hi).
+    ///
+    /// Non-finite input and a non-positive interval fail closed to lo, and the
+    /// quotient is floored in double rather than through iFloor. This is reachable
+    /// from a client packet: MoveSpline normalizes the orientation the client
+    /// reports, so a NaN or a value beyond 2^31 intervals from lo used to convert a
+    /// double to int out of range -- undefined behaviour, not a wrong angle. Inside
+    /// the range every caller actually uses, the value is unchanged.
     inline float wrap(float t, float lo, float hi)
     {
+        const float interval = hi - lo;
+        if (!(interval > 0.0f) || !isFinite(t))
+        {
+            return lo;
+        }
+
         if ((t >= lo) && (t < hi))
         {
             return t;
         }
 
-        const float interval = hi - lo;
-        return t - interval * iFloor((t - lo) / interval);
+        const double turns = std::floor((double(t) - double(lo)) / double(interval));
+        return float(double(t) - double(interval) * turns);
     }
 }

--- a/src/shared/Geometry/Placement.h
+++ b/src/shared/Geometry/Placement.h
@@ -97,14 +97,20 @@ namespace Geometry
                            : Unreachable();
             }
 
+            /// A bare point carries no frame, so the only thing that can disqualify the
+            /// comparison is this placement having none either -- and then it fails
+            /// closed like every other cross-frame answer. An item in a bag must not
+            /// measure its distance from the origin of a map it is not on.
             float DistanceTo(const Vector3& point, bool is3D = true) const
             {
-                return Gap(std::sqrt(SeparationSq(point, is3D)), m_extent);
+                return IsPlaced() ? Gap(std::sqrt(SeparationSq(point, is3D)), m_extent)
+                                  : Unreachable();
             }
 
             float DistanceTo(const Vector2& point) const
             {
-                return Gap(std::sqrt(SeparationSq2D(point)), m_extent);
+                return IsPlaced() ? Gap(std::sqrt(SeparationSq2D(point)), m_extent)
+                                  : Unreachable();
             }
 
             float HeightGapTo(const Placement& other) const
@@ -122,12 +128,12 @@ namespace Geometry
 
             bool WithinDist(const Vector3& point, float dist, bool is3D = true) const
             {
-                return Closer(SeparationSq(point, is3D), dist, m_extent);
+                return IsPlaced() && Closer(SeparationSq(point, is3D), dist, m_extent);
             }
 
             bool WithinDist(const Vector2& point, float dist) const
             {
-                return Closer(SeparationSq2D(point), dist, m_extent);
+                return IsPlaced() && Closer(SeparationSq2D(point), dist, m_extent);
             }
 
             bool WithinRange(const Placement& other, float minRange, float maxRange, bool is3D = true) const
@@ -138,18 +144,22 @@ namespace Geometry
 
             bool WithinRange(const Vector3& point, float minRange, float maxRange, bool is3D = true) const
             {
-                return InBand(SeparationSq(point, is3D), minRange, maxRange, m_extent);
+                return IsPlaced() && InBand(SeparationSq(point, is3D), minRange, maxRange, m_extent);
             }
 
             bool WithinRange(const Vector2& point, float minRange, float maxRange) const
             {
-                return InBand(SeparationSq2D(point), minRange, maxRange, m_extent);
+                return IsPlaced() && InBand(SeparationSq2D(point), minRange, maxRange, m_extent);
             }
 
             /// A zero tolerance skips that axis; all-zero matches nothing, as the database's
             /// integer waypoint tolerances have always meant.
             bool WithinBox(const Vector3& point, const Vector3& tolerance) const
             {
+                if (!IsPlaced())
+                {
+                    return false;
+                }
                 if (tolerance.x <= 0.0f && tolerance.y <= 0.0f && tolerance.z <= 0.0f)
                 {
                     return false;
@@ -209,13 +219,25 @@ namespace Geometry
                 return SignedOrientation(BearingTo(point) - m_facing);
             }
 
+            /// @p arc is the FULL width of the cone, centred on the facing.
+            ///
+            /// It must not go through NormalizeOrientation. That wraps into the
+            /// half-open [0, 2*PI), so a full circle -- the natural way to spell "in any
+            /// direction", and what IsInBack() below computes for an arc of zero -- came
+            /// back as zero, halved to zero, and matched only a target dead ahead. An
+            /// angle that names a direction and an angle that names a width are
+            /// different things wearing the same type.
             bool HasInArc(const Placement& other, float arc) const
             {
-                if (!ShareFrame(other))
+                if (!ShareFrame(other) || !(arc > 0.0f))
                 {
                     return false;
                 }
-                const float half = NormalizeOrientation(arc) / 2.0f;
+                if (arc >= TwoPi())
+                {
+                    return true;
+                }
+                const float half = arc / 2.0f;
                 const float bearing = RelativeBearingTo(other);
                 return bearing >= -half && bearing <= half;
             }
@@ -276,10 +298,15 @@ namespace Geometry
                 return dx * dx + dy * dy;
             }
 
+            /// CLOSED. Exactly at the limit counts as within, which is what makes
+            /// WithinDist(other, DistanceTo(other)) true. With a strict compare the two
+            /// disagreed by construction: DistanceTo returns the separation minus the
+            /// extents, and feeding that straight back asked whether a number is less
+            /// than itself.
             static bool Closer(float separationSq, float dist, float extentSum)
             {
                 const float reach = dist + extentSum;
-                return separationSq < reach * reach;
+                return separationSq <= reach * reach;
             }
 
             static bool InBand(float separationSq, float minRange, float maxRange, float extentSum)
@@ -293,7 +320,7 @@ namespace Geometry
                     }
                 }
                 const float far_ = maxRange + extentSum;
-                return separationSq < far_ * far_;
+                return separationSq <= far_ * far_;
             }
 
             Frame m_frame;

--- a/src/shared/Geometry/Quat.h
+++ b/src/shared/Geometry/Quat.h
@@ -11,7 +11,9 @@
 #include "Geometry/GeometryMath.h"
 #include "Geometry/Vector3.h"
 
+#include <cstddef>
 #include <cstdint>
+#include <type_traits>
 
 #include <cmath>
 
@@ -65,7 +67,20 @@ namespace Geometry
             }
 
             /// Make unit length in place.
-            void unitize() { *this *= rsq(dot(*this)); }
+            ///
+            /// A zero quaternion has no direction to normalise towards; it becomes the
+            /// identity rather than four NaNs that every later comparison reads as
+            /// "not equal, not unit, not finite" without anything reporting an error.
+            void unitize()
+            {
+                const float lengthSq = dot(*this);
+                if (!(lengthSq > 0.0f) || !Geometry::isFinite(lengthSq))
+                {
+                    *this = Quat();
+                    return;
+                }
+                *this *= rsq(lengthSq);
+            }
 
             float magnitude() const { return std::sqrt(dot(*this)); }
 
@@ -73,6 +88,18 @@ namespace Geometry
     };
 
     inline Quat operator*(float s, const Quat& q) { return q * s; }
+
+    // The layout note at the top of this file is a requirement, not a description:
+    // imag() reinterpret_casts x,y,z onto a Vector3. Add a member, a base or a virtual
+    // and that cast still compiles, still links, and reads the wrong three floats.
+    static_assert(sizeof(Quat) == 4 * sizeof(float),
+                  "Quat::imag aliases x,y,z as a Vector3: it must be four bare floats");
+    static_assert(std::is_standard_layout<Quat>::value,
+                  "Quat::imag aliases x,y,z as a Vector3: it must be standard layout");
+    static_assert(offsetof(Quat, x) == 0 && offsetof(Quat, y) == sizeof(float) &&
+                  offsetof(Quat, z) == 2 * sizeof(float) &&
+                  offsetof(Quat, w) == 3 * sizeof(float),
+                  "Quat members must stay in x,y,z,w order with no padding");
 
     /// The yaw a rotation carries, in [0, 2*PI) -- the only component a server-side
     /// facing has, since everything the core places stands upright.

--- a/src/shared/Geometry/Shapes.h
+++ b/src/shared/Geometry/Shapes.h
@@ -48,12 +48,23 @@ namespace Geometry
             hi.y = std::max(hi.y, p.y);
             hi.z = std::max(hi.z, p.z);
         }
+        // An empty box is lo = +max, hi = -max. Expanding by one would poison this
+        // accumulator into a full-span range -- lo = -max and hi = +max, whose extent
+        // overflows to infinity -- and the SAH cost of every split then compares equal.
+        // The BVH still builds, still loads, and stops separating anything.
         void expand(const Aabb& b)
         {
+            if (!b.valid())
+            {
+                return;
+            }
             expand(b.lo);
             expand(b.hi);
         }
-        bool valid() const { return lo.x <= hi.x; }
+        // All three axes: an accumulator that has seen one point is valid on every axis,
+        // and one that has seen none is valid on none. Testing x alone calls a box whose
+        // y or z never got a value valid, and Surface() then reads garbage extents.
+        bool valid() const { return lo.x <= hi.x && lo.y <= hi.y && lo.z <= hi.z; }
 
         // Does the vertical line at (px,py) pass through this box's XY footprint?
         bool coversColumn(float px, float py) const
@@ -87,8 +98,32 @@ namespace Geometry
             float t0 = 0.f, t1 = tMax;
             for (int a = 0; a < 3; ++a)
             {
-                const float oa = (&o.x)[a], id = (&invDir.x)[a];
-                const float loa = (&lo.x)[a] - kSlabEps, hia = (&hi.x)[a] + kSlabEps;
+                const float oa = o[a], id = invDir[a];
+                const float loa = lo[a] - kSlabEps, hia = hi[a] + kSlabEps;
+
+                // A non-finite reciprocal makes every comparison below unreliable, and
+                // the failure is one-sided: std::max(t0, NaN) returns t0 and
+                // std::min(t1, NaN) returns t1, so the axis is silently DROPPED and the
+                // box is accepted. An infinite reciprocal (a zero direction component)
+                // still rejects correctly through the infinities, except when the origin
+                // sits exactly on a slab face and the product becomes 0 * inf; a NaN
+                // reciprocal -- what a direction of zero length normalises to, and what
+                // 1/NaN gives -- drops the axis for EVERY origin, so a degenerate ray
+                // matches every node it is offered.
+                //
+                // On such an axis the ray neither enters nor leaves the slab, so the only
+                // question left is whether it started inside one. Measured against the
+                // PADDED bounds, so this stays exactly as permissive as the slab test
+                // above and never tightens it below rayTri's tolerance.
+                if (!std::isfinite(id))
+                {
+                    if (oa < loa || oa > hia)
+                    {
+                        return false;
+                    }
+                    continue;
+                }
+
                 float ta = (loa - oa) * id, tb = (hia - oa) * id;
                 if (ta > tb)
                 {

--- a/src/shared/Geometry/Vector3.h
+++ b/src/shared/Geometry/Vector3.h
@@ -72,9 +72,18 @@ namespace Geometry
             float magnitude() const { return std::sqrt(x * x + y * y + z * z); }
             float length() const { return magnitude(); }
 
+            /// The zero vector has no direction, and 1/sqrt(0) is infinity: the result
+            /// would be all NaN, isFinite() would say so, and every comparison against
+            /// it would quietly be false -- a ray that misses instead of a call that
+            /// fails. Zero in, zero out; the same for a non-finite magnitude.
             Vector3 direction() const
             {
-                const float invSqrt = 1.0f / std::sqrt(squaredMagnitude());
+                const float lengthSq = squaredMagnitude();
+                if (!(lengthSq > 0.0f) || !Geometry::isFinite(lengthSq))
+                {
+                    return zero();
+                }
+                const float invSqrt = rsq(lengthSq);
                 return Vector3(x * invSqrt, y * invSqrt, z * invSqrt);
             }
             Vector3 unit() const { return direction(); }

--- a/src/shared/terrain/Accelerators.cpp
+++ b/src/shared/terrain/Accelerators.cpp
@@ -37,6 +37,71 @@ namespace world::terrain
     static_assert(std::is_trivially_copyable<Bvh::Node>::value,
                   "Bvh::Node must stay trivially copyable (it is written raw to the tile)");
 
+    bool TriSoup::IndicesValid() const
+    {
+        const uint32_t count = uint32_t(verts.size());
+        for (const std::array<uint32_t, 3>& tri : tris)
+        {
+            if (tri[0] >= count || tri[1] >= count || tri[2] >= count)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool Bvh::Adopt(std::vector<Node> nodes, size_t triangleCount)
+    {
+        m_nodes.clear();
+        m_maxDepth = 0;
+        if (nodes.empty())
+        {
+            return true;
+        }
+
+        // One forward sweep. BuildNode appends the parent before either child, so a
+        // child index is always greater than its parent's; requiring that makes a cycle
+        // unrepresentable, and reaching a node before its parent impossible -- which is
+        // what lets the depth be known by the time the node itself is examined.
+        const int64_t size = int64_t(nodes.size());
+        std::vector<int> depth(nodes.size(), -1);
+        depth[0] = 0;
+
+        for (size_t i = 0; i < nodes.size(); ++i)
+        {
+            const Node& node = nodes[i];
+            if (depth[i] < 0 || depth[i] > MAX_DEPTH)
+            {
+                return false;                       // unreachable, or too deep to walk
+            }
+
+            if (node.left < 0)
+            {
+                // A leaf's run must lie inside the soup: Raycast reads it unchecked.
+                if (uint64_t(node.first) + node.count > triangleCount)
+                {
+                    return false;
+                }
+                continue;
+            }
+
+            const int64_t left = node.left;
+            const int64_t right = node.right;
+            if (left <= int64_t(i) || right <= int64_t(i) || left >= size || right >= size ||
+                left == right || depth[size_t(left)] >= 0 || depth[size_t(right)] >= 0)
+            {
+                return false;
+            }
+
+            depth[size_t(left)] = depth[i] + 1;
+            depth[size_t(right)] = depth[i] + 1;
+            m_maxDepth = std::max(m_maxDepth, depth[i] + 1);
+        }
+
+        m_nodes = std::move(nodes);
+        return true;
+    }
+
     void Bvh::Build(TriSoup& soup, std::vector<uint16_t>* parallel, int leafSize)
     {
         m_nodes.clear();
@@ -89,7 +154,13 @@ namespace world::terrain
         }
         m_nodes[self].box = box;
 
-        if (count <= uint32_t(leafSize) || depth > MAX_DEPTH)
+        // Cut off AT MAX_DEPTH, not past it. The comment on MAX_DEPTH says it is the
+        // deepest node Build will create and that Raycast's stack is sized from it; a
+        // strict compare made the deepest node MAX_DEPTH + 1, so the two were out of
+        // step in the one direction that matters. Adopt now rejects anything deeper on
+        // load, and a soup of coincident centroids -- which is what drives the split
+        // this deep -- would otherwise bake a tree that fails to reload.
+        if (count <= uint32_t(leafSize) || depth >= MAX_DEPTH)
         {
             m_nodes[self].left = -1;
             m_nodes[self].first = first;

--- a/src/shared/terrain/Accelerators.hpp
+++ b/src/shared/terrain/Accelerators.hpp
@@ -42,6 +42,12 @@ namespace world::terrain
         }
 
         size_t Size() const { return tris.size(); }
+
+        /// At() indexes verts blindly, because the query path cannot afford a bounds
+        /// test per triangle. That is only sound if the soup was screened ONCE, when it
+        /// came off disk: a bit-flip in a .tile otherwise becomes an out-of-bounds read
+        /// inside a raycast, which is the one place nothing is watching.
+        bool IndicesValid() const;
     };
 
     class Bvh
@@ -85,7 +91,25 @@ namespace world::terrain
                         std::vector<Crossing>& out) const;
 
         const std::vector<Node>& Nodes() const { return m_nodes; }
-        void Adopt(std::vector<Node> nodes) { m_nodes = std::move(nodes); }
+
+        /**
+         * @brief Take a node array read from disk, after checking it really is a tree.
+         *
+         * Nothing downstream re-checks. Raycast pushes both children unconditionally
+         * onto a stack sized from MAX_DEPTH, indexes m_nodes with whatever it popped,
+         * and reads a leaf's triangle run without a bounds test. All three are safe
+         * only because Build cannot emit a node array that violates them -- a FILE can,
+         * whether corrupt or hostile, and the tile format has no checksum.
+         *
+         * The check requires each child's index to exceed its parent's. That is the
+         * layout Build emits (the parent is appended before either child) and it is
+         * therefore part of the tile format, not an implementation detail: it makes a
+         * cycle unrepresentable, which is what lets the depth pass be one forward sweep.
+         *
+         * @return false when the array is not a depth-first tree over @p triangleCount
+         *         triangles; the tree is left empty and the caller must reject the tile.
+         */
+        bool Adopt(std::vector<Node> nodes, size_t triangleCount);
 
         size_t NodeCount() const { return m_nodes.size(); }
         int MaxDepth() const { return m_maxDepth; }

--- a/src/shared/terrain/FusedTerrain.cpp
+++ b/src/shared/terrain/FusedTerrain.cpp
@@ -68,20 +68,25 @@ namespace world::terrain
     {
     }
 
+    // READ, not stat. This answers the start-up question "does this map have terrain",
+    // and a file that opens is not an answer: a truncated tile, one from another build,
+    // or one whose grids are the wrong shape passes an existence check and then fails
+    // inside ReadTile, after which every height, liquid and collision query silently
+    // answers nothing at all. The whole point of asking at start-up is to fail loudly
+    // instead. It is asked once per checked grid, never on a query path, so parsing the
+    // file is affordable -- the first query would have parsed it anyway.
     bool FusedTerrain::HasTile(uint32_t mapId, int tx, int ty)
     {
         if (g_tileDir.empty())
         {
             return false;
         }
-        if (std::ifstream(g_tileDir + "/" + TileFileName(mapId, tx, ty),
-                          std::ios::binary).good())
+        if (ReadTile(g_tileDir + "/" + TileFileName(mapId, tx, ty)))
         {
             return true;
         }
         // A map built from one global WMO carries no ADT grid tiles at all.
-        return std::ifstream(g_tileDir + "/" + GlobalWmoFileName(mapId),
-                             std::ios::binary).good();
+        return ReadTile(g_tileDir + "/" + GlobalWmoFileName(mapId)) != nullptr;
     }
 
     FusedTerrain::TilePtr FusedTerrain::LoadCell(int tx, int ty) const
@@ -210,8 +215,16 @@ namespace world::terrain
         {
             return;
         }
+        // SATURATING, not wrapping. m_cellRef is an int16_t, so 32767 pins on one cell
+        // is not an unreachable number for a leaked pin; signed overflow is undefined,
+        // and the observable outcome of wrapping is worse than the leak it replaces --
+        // the count goes NEGATIVE, the cell reads as unpinned, and the sweep evicts a
+        // tile that is still in use.
         std::lock_guard<std::mutex> lock(m_cellRefMutex);
-        ++m_cellRef[tx][ty];
+        if (m_cellRef[tx][ty] < std::numeric_limits<int16_t>::max())
+        {
+            ++m_cellRef[tx][ty];
+        }
     }
 
     void FusedTerrain::UnpinCell(int tx, int ty)
@@ -361,12 +374,13 @@ namespace world::terrain
                                                std::vector<const StaticInstance*>& out,
                                                std::vector<TilePtr>& keepAlive) const
     {
+        out.clear();
+        keepAlive.clear();
+
         const float minx = std::min(a.x, b.x), maxx = std::max(a.x, b.x);
         const float miny = std::min(a.y, b.y), maxy = std::max(a.y, b.y);
 
         const float dx = b.x - a.x, dy = b.y - a.y;
-        const float lengthXY = std::sqrt(dx * dx + dy * dy);
-        const int samples = std::max(2, int(lengthXY / (TILE_SIZE * 0.5f)) + 2);
 
         auto gather = [&](const TilePtr& tile)
         {
@@ -386,23 +400,122 @@ namespace world::terrain
             }
         };
 
-        int lastTx = 0, lastTy = 0;
-        bool seen = false;
-        for (int i = 0; i < samples; ++i)
+        // SUPERCOVER walk of the tiles the XY segment touches (Amanatides-Woo).
+        //
+        // This used to sample the segment every half tile and take the tile under each
+        // sample. A sample step can only guarantee the tiles it lands in, and a segment
+        // that clips the CORNER of a tile -- entering and leaving between two samples --
+        // is missed entirely. The tile is then never gathered, so a wall standing in it
+        // occludes nothing: the sight line reads clear straight through solid geometry,
+        // and only from the angles that clip that corner. Halving the step does not fix
+        // it, it only moves the angle at which it happens.
+        //
+        // A walk cannot miss a tile the segment enters, because it advances to the next
+        // BOUNDARY rather than to the next sample.
+        auto visit = [&](int tx, int ty)
         {
-            const float f = float(i) / float(samples - 1);
-            const float px = a.x + dx * f, py = a.y + dy * f;
-            const int tx = TileIndex(px), ty = TileIndex(py);
-            if (seen && tx == lastTx && ty == lastTy)
+            if (tx < 0 || tx >= GRID_COUNT || ty < 0 || ty >= GRID_COUNT)
             {
-                continue;
+                return;
             }
-            seen = true;
-            lastTx = tx;
-            lastTy = ty;
-            if (tx >= 0 && tx < GRID_COUNT && ty >= 0 && ty < GRID_COUNT)
+            // The centre of that tile, which is what TileAt() takes. Tile tx spans world
+            // x in ((MAP_CENTER - tx - 1) * TILE_SIZE, (MAP_CENTER - tx) * TILE_SIZE].
+            const float px = (float(MAP_CENTER) - (float(tx) + 0.5f)) * TILE_SIZE;
+            const float py = (float(MAP_CENTER) - (float(ty) + 0.5f)) * TILE_SIZE;
+            gather(TileAt(px, py));
+        };
+
+        const int startTx = TileIndex(a.x), startTy = TileIndex(a.y);
+        const int endTx = TileIndex(b.x), endTy = TileIndex(b.y);
+
+        if (startTx == endTx && startTy == endTy)
+        {
+            visit(startTx, startTy);
+        }
+        else
+        {
+            // A tile index DECREASES as the world coordinate grows, so travelling
+            // towards +x steps towards a smaller tx.
+            const int stepX = (dx > 0.0f) ? -1 : (dx < 0.0f ? 1 : 0);
+            const int stepY = (dy > 0.0f) ? -1 : (dy < 0.0f ? 1 : 0);
+
+            const float absDx = std::fabs(dx), absDy = std::fabs(dy);
+            constexpr float NEVER = 1e30f;
+
+            // How much of the segment one whole tile costs on each axis, and how much of
+            // it is left before the first boundary. Both in the parameter t of [0, 1].
+            const float tDeltaX = (absDx < 1e-6f) ? NEVER : (TILE_SIZE / absDx);
+            const float tDeltaY = (absDy < 1e-6f) ? NEVER : (TILE_SIZE / absDy);
+
+            float tMaxX = NEVER;
+            float tMaxY = NEVER;
+            if (stepX != 0)
             {
-                gather(TileAt(px, py));
+                // Towards +x (stepX < 0) the next boundary is the tile's high edge.
+                const float nextX = (float(MAP_CENTER) -
+                                     float(stepX < 0 ? startTx : startTx + 1)) * TILE_SIZE;
+                tMaxX = std::max(0.0f, (nextX - a.x) / dx);
+            }
+            if (stepY != 0)
+            {
+                const float nextY = (float(MAP_CENTER) -
+                                     float(stepY < 0 ? startTy : startTy + 1)) * TILE_SIZE;
+                tMaxY = std::max(0.0f, (nextY - a.y) / dy);
+            }
+
+            int tx = startTx, ty = startTy;
+            visit(tx, ty);
+
+            // A continent's diagonal is 64 tiles, so a sight line between two points on
+            // the map needs at most 129 steps. The cap is a backstop for a segment whose
+            // endpoints are off the map entirely, never a limit a real one reaches.
+            for (int guard = 0; guard < 4 * GRID_COUNT; ++guard)
+            {
+                if (tx == endTx && ty == endTy)
+                {
+                    break;
+                }
+                if (tMaxX < tMaxY)
+                {
+                    if (tMaxX > 1.0f)
+                    {
+                        break;
+                    }
+                    tx += stepX;
+                    tMaxX += tDeltaX;
+                }
+                else if (tMaxY < tMaxX)
+                {
+                    if (tMaxY > 1.0f)
+                    {
+                        break;
+                    }
+                    ty += stepY;
+                    tMaxY += tDeltaY;
+                }
+                else
+                {
+                    // Exactly through a grid corner. Stepping straight to the diagonal
+                    // would skip the two edge-adjacent tiles the segment still clips --
+                    // the very case this walk exists for -- so both are visited first.
+                    if (tMaxX > 1.0f)
+                    {
+                        break;
+                    }
+                    if (stepX != 0)
+                    {
+                        visit(tx + stepX, ty);
+                    }
+                    if (stepY != 0)
+                    {
+                        visit(tx, ty + stepY);
+                    }
+                    tx += stepX;
+                    ty += stepY;
+                    tMaxX += tDeltaX;
+                    tMaxY += tDeltaY;
+                }
+                visit(tx, ty);
             }
         }
 

--- a/src/shared/terrain/FusedTerrain.cpp
+++ b/src/shared/terrain/FusedTerrain.cpp
@@ -242,9 +242,19 @@ namespace world::terrain
     }
 
     Column FusedTerrain::ColumnAt(float x, float y, float zTop, float zBottom,
-                                  const ILiveGeometry* live, uint32_t filter) const
+                                  const ILiveGeometry* live, uint32_t filter,
+                                  uint32_t sources) const
     {
         Column column;
+
+        // Each source is asked for separately below. Excluding one is not the same as
+        // finding nothing in it: the column simply never hears about that kind of
+        // surface, and every selection over it -- floor, ceiling, water level -- answers
+        // from what is left, which is exactly what turning baked collision off means.
+        const bool wantTerrain = (sources & SOURCE_TERRAIN) != 0;
+        const bool wantStatic = (sources & SOURCE_STATIC) != 0;
+        const bool wantStaticLiquid = (sources & SOURCE_STATIC_LIQUID) != 0;
+        const bool wantLive = (sources & SOURCE_LIVE) != 0;
 
         TilePtr tile = TileAt(x, y);
         TilePtr global = GlobalWmo();
@@ -257,7 +267,7 @@ namespace world::terrain
         // tile already holds, so there is nothing to gain by hiding it, and a caller
         // probing from far above (MAX_HEIGHT) would otherwise get an empty column on a
         // map whose only surface is terrain.
-        if (tile)
+        if (tile && wantTerrain)
         {
             if (auto h = tile->TerrainHeight(x, y))
             {
@@ -298,11 +308,19 @@ namespace world::terrain
 
                 // localToWorld(o + t*d) == originWorld + t*downWorld, so t is already a
                 // world distance whatever the instance scale.
-                hits.clear();
-                inst.model->RaycastAll(originLocal, dirLocal, span, hits);
-                for (const float t : hits)
+                if (wantStatic)
                 {
-                    column.AddSolid(zTop - t, SurfaceKind::Static);
+                    hits.clear();
+                    inst.model->RaycastAll(originLocal, dirLocal, span, hits);
+                    for (const float t : hits)
+                    {
+                        column.AddSolid(zTop - t, SurfaceKind::Static);
+                    }
+                }
+
+                if (!wantStaticLiquid)
+                {
+                    continue;
                 }
 
                 // The ray origin doubles as the liquid probe: MLIQ is indexed by local X
@@ -332,16 +350,19 @@ namespace world::terrain
             }
         };
 
-        if (tile)
+        if (wantStatic || wantStaticLiquid)
         {
-            probe(tile->instances);
-        }
-        if (global && global != tile)
-        {
-            probe(global->instances);
+            if (tile)
+            {
+                probe(tile->instances);
+            }
+            if (global && global != tile)
+            {
+                probe(global->instances);
+            }
         }
 
-        if (tile)
+        if (tile && wantTerrain)
         {
             if (auto adt = tile->LiquidAt(x, y))
             {
@@ -349,7 +370,7 @@ namespace world::terrain
             }
         }
 
-        if (live)
+        if (live && wantLive)
         {
             live->AddSurfaces(x, y, zTop, zBottom, filter, column);
         }

--- a/src/shared/terrain/FusedTerrain.hpp
+++ b/src/shared/terrain/FusedTerrain.hpp
@@ -46,6 +46,19 @@ namespace world::terrain
         static const std::string& TileDir();
         static bool HasTile(uint32_t mapId, int tx, int ty);
 
+        // Which kinds of surface a gather is allowed to report. Whole categories, never
+        // individual objects, and the engine attaches no meaning to WHY one is excluded:
+        // the server has a table that turns baked collision off per map, and translating
+        // a row of it into these bits is the caller's business, not this side's.
+        enum SurfaceSources : uint32_t
+        {
+            SOURCE_TERRAIN       = 0x1,  ///< the ADT heightmap and its own liquid
+            SOURCE_STATIC        = 0x2,  ///< baked WMO and M2 floors
+            SOURCE_STATIC_LIQUID = 0x4,  ///< liquid authored inside a WMO
+            SOURCE_LIVE          = 0x8,  ///< whatever `live` poses at runtime
+            SOURCE_ALL           = 0xF
+        };
+
         // THE height query. Every surface crossing the window [zBottom, zTop] over (x,y):
         // the ADT heightmap, each baked static, the liquid surface, and -- when `live` is
         // given -- the bodies the game poses at runtime. `filter` reaches that provider
@@ -56,7 +69,8 @@ namespace world::terrain
         // ask a question the entry point had not anticipated, and four layers each kept
         // their own idea of which surface "the ground" meant. Select on the Column.
         Column ColumnAt(float x, float y, float zTop, float zBottom,
-                        const ILiveGeometry* live = nullptr, uint32_t filter = 0) const;
+                        const ILiveGeometry* live = nullptr, uint32_t filter = 0,
+                        uint32_t sources = SOURCE_ALL) const;
 
         // Nearest static hit along a->b as a fraction of the segment; > 1 when nothing
         // blocks. A fraction rather than a point on purpose: the static and dynamic

--- a/src/shared/terrain/GoModelStore.cpp
+++ b/src/shared/terrain/GoModelStore.cpp
@@ -27,18 +27,26 @@ namespace world::terrain
 
     std::shared_ptr<const ICollisionModel> GoModelStore::Get(uint32_t displayId)
     {
-        std::lock_guard<std::mutex> lock(m_mutex);
-
-        auto found = m_models.find(displayId);
-        if (found != m_models.end())
+        std::string dir;
         {
-            return found->second;
+            std::lock_guard<std::mutex> lock(m_mutex);
+            auto found = m_models.find(displayId);
+            if (found != m_models.end())
+            {
+                return found->second;
+            }
+            dir = m_dir;
         }
 
+        // The file is read OUTSIDE the lock. Held across the open, one disk read
+        // serialises every game-object spawn in the world behind it -- unnoticeable at
+        // boot, where the same thread does them one after another anyway, and a stall
+        // on every map-update thread at once when a fight pulls in a display id nobody
+        // has touched yet.
         std::shared_ptr<const ICollisionModel> model;
-        if (!m_dir.empty())
+        if (!dir.empty())
         {
-            if (auto tile = ReadTile(m_dir + "/" + GoModelFileName(displayId)))
+            if (auto tile = ReadTile(dir + "/" + GoModelFileName(displayId)))
             {
                 if (!tile->instances.empty())
                 {
@@ -47,9 +55,16 @@ namespace world::terrain
             }
         }
 
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (dir != m_dir)
+        {
+            return model;               // SetDirectory ran under us; do not cache it
+        }
+
         // A null is cached too: it records that this display id has no collision, which
-        // is true of most of them, and spares a failed open per spawn.
-        m_models.emplace(displayId, model);
-        return model;
+        // is true of most of them, and spares a failed open per spawn. Two threads that
+        // raced on the same id both read the file; emplace keeps whichever arrived
+        // first, so every caller still shares one model.
+        return m_models.emplace(displayId, model).first->second;
     }
 }

--- a/src/shared/terrain/Terrain.hpp
+++ b/src/shared/terrain/Terrain.hpp
@@ -22,7 +22,13 @@ namespace world::terrain
     constexpr int FusedTerrainGridCount = 64;
 
     inline float GridCoord(float c) { return GRID_PER_TILE * (MAP_CENTER - c / TILE_SIZE); }
-    inline int TileIndex(float c) { return static_cast<int>(GridCoord(c)) >> 7; }
+
+    /// FLOOR, not truncate. The shift already floors for a negative grid coordinate,
+    /// but the conversion to int in front of it truncates toward zero: a grid
+    /// coordinate in (-1, 0) -- the 4.16-yard strip at the far corner of the map --
+    /// became 0 >> 7 = tile 0 instead of tile -1, so a point off one edge was answered
+    /// with the tile off the opposite one.
+    inline int TileIndex(float c) { return static_cast<int>(std::floor(GridCoord(c))) >> 7; }
 
     enum class LiquidKind : uint8_t
     {

--- a/src/shared/terrain/TileSerializer.cpp
+++ b/src/shared/terrain/TileSerializer.cpp
@@ -6,6 +6,7 @@
 #include "terrain/WmoModel.hpp"
 
 #include <array>
+#include <cmath>
 #include <cstdio>
 #include <unordered_map>
 
@@ -14,10 +15,23 @@ namespace world::terrain
     namespace
     {
         constexpr uint32_t MAGIC = 0x32474E4D;  // "MNG2" in file order
-        constexpr uint32_t VERSION = 1;
+        // Version 2 is the same byte LAYOUT as 1 and a different set of accepted files.
+        // The reader now requires each present grid to match its fixed dimensions, a WMO
+        // group's liquid to match its own tile counts, a BVH node array to be a tree over
+        // the triangles it indexes, and an instance to carry a finite pose -- all of which
+        // a version 1 bake was free to violate. A tile that does is now REJECTED, and a
+        // rejected tile is silence: no height, no liquid, no collision, no diagnostic
+        // beyond the miss. The version is what turns "this map answers nothing" into
+        // "this bake is stale, run the extractor".
+        constexpr uint32_t VERSION = 2;
 
         constexpr uint32_t MAX_MODELS = 1u << 20;
         constexpr uint32_t MAX_INSTANCES = 1u << 22;
+        // A WMO's group count is a uint32 in the file and a few hundred in reality. The
+        // model ceiling is far too loose for it: it lets a corrupt header size a vector
+        // of a million groups -- each one a Group with two vectors inside -- before any
+        // per-group read measures anything against the file.
+        constexpr uint32_t MAX_GROUPS = 4096;
 
         // A count is only believable if the file still holds that many elements. A fixed
         // ceiling is not enough: it still lets a corrupt header reserve hundreds of
@@ -92,6 +106,65 @@ namespace world::terrain
             return std::fread(a.data(), sizeof(T), N, f) == N;
         }
 
+        // MLIQ is a (tilesX+1) x (tilesY+1) grid of corner heights over a tilesX x tilesY
+        // grid of flags. WmoModel::LiquidLocal interpolates the four corners around a
+        // point with no bounds test, so a pair of counts that does not match the vectors
+        // is an out-of-bounds read at query time -- long after the file was accepted.
+        bool LiquidSizesOk(uint32_t tilesX, uint32_t tilesY,
+                           const std::vector<float>& heights,
+                           const std::vector<uint8_t>& flags)
+        {
+            if (tilesX == 0 || tilesY == 0)
+            {
+                return false;
+            }
+            const size_t wantHeights = size_t(tilesX + 1) * size_t(tilesY + 1);
+            const size_t wantFlags = size_t(tilesX) * size_t(tilesY);
+            return heights.size() == wantHeights && flags.size() == wantFlags;
+        }
+
+        // The height and liquid grids are indexed by fixed arithmetic over the tile's
+        // constant dimensions -- TerrainHeight and LiquidAt never look at .size(). A
+        // short vector read off disk is therefore not a wrong height, it is a read past
+        // the end of the allocation.
+        bool TerrainGridSizesOk(const TerrainTile& tile)
+        {
+            constexpr size_t V9 = size_t(V9_SIDE) * size_t(V9_SIDE);
+            constexpr size_t V8 = size_t(GRID_PER_TILE) * size_t(GRID_PER_TILE);
+
+            if (tile.hasTerrain && (tile.v9.size() != V9 || tile.v8.size() != V8))
+            {
+                return false;
+            }
+            if (tile.hasLiquid &&
+                (tile.liquidHeight.size() != V9 || tile.liquidShow.size() != V8 ||
+                 tile.liquidKind.size() != V8 || tile.liquidEntry.size() != V8 ||
+                 tile.liquidDeep.size() != V8))
+            {
+                return false;
+            }
+            return true;
+        }
+
+        // The bake writes proper rotation matrices, so |det| is 1. Anything else is a
+        // corrupt placement, and a non-finite one poisons every ray transformed by it.
+        bool RotationOk(const Mat3& rot)
+        {
+            for (const float c : rot.m)
+            {
+                if (!std::isfinite(c))
+                {
+                    return false;
+                }
+            }
+            const auto& m = rot.m;
+            const float det = m[0] * (m[4] * m[8] - m[5] * m[7]) -
+                              m[1] * (m[3] * m[8] - m[5] * m[6]) +
+                              m[2] * (m[3] * m[7] - m[4] * m[6]);
+            constexpr float eps = 1e-3f;
+            return std::fabs(det - 1.0f) < eps || std::fabs(det + 1.0f) < eps;
+        }
+
         bool WriteGroup(std::FILE* f, const WmoModel::Group& g)
         {
             bool ok = WPod(f, g.mogpFlags) && WPod(f, g.groupWmoId);
@@ -99,6 +172,8 @@ namespace world::terrain
             ok = ok && WPod(f, hasLiquid);
             if (g.hasLiquid)
             {
+                ok = ok && LiquidSizesOk(g.liquid.tilesX, g.liquid.tilesY,
+                                         g.liquid.heights, g.liquid.flags);
                 ok = ok && WPod(f, g.liquid.tilesX) && WPod(f, g.liquid.tilesY) &&
                      WPod(f, g.liquid.corner) && WPod(f, g.liquid.entry) &&
                      WPod(f, g.liquid.kind) && WVec(f, g.liquid.heights) &&
@@ -119,6 +194,8 @@ namespace world::terrain
                      RPod(f, g.liquid.corner) && RPod(f, g.liquid.entry) &&
                      RPod(f, g.liquid.kind) && RVec(f, g.liquid.heights) &&
                      RVec(f, g.liquid.flags);
+                ok = ok && LiquidSizesOk(g.liquid.tilesX, g.liquid.tilesY,
+                                         g.liquid.heights, g.liquid.flags);
             }
             return ok;
         }
@@ -157,7 +234,8 @@ namespace world::terrain
         const uint8_t globalWmo = tile.isGlobalWmo ? 1 : 0;
         const uint8_t hasLiquid = tile.hasLiquid ? 1 : 0;
 
-        bool ok = WPod(f, MAGIC) && WPod(f, VERSION) && WPod(f, tile.tx) &&
+        bool ok = TerrainGridSizesOk(tile);
+        ok = ok && WPod(f, MAGIC) && WPod(f, VERSION) && WPod(f, tile.tx) &&
                   WPod(f, tile.ty) && WPod(f, hasTerrain) && WPod(f, globalWmo) &&
                   WVec(f, tile.v9) && WVec(f, tile.v8) && WArray(f, tile.holes) &&
                   WArray(f, tile.areaIds) && WPod(f, hasLiquid) &&
@@ -217,7 +295,10 @@ namespace world::terrain
                  WPod(f, inst.worldBounds.hi) && WPod(f, idx) && WPod(f, inst.adtId);
         }
 
-        std::fclose(f);
+        // fclose is what flushes: a write that failed only in the buffer -- a full disk
+        // is the ordinary way -- reports success here and leaves a truncated tile that
+        // looks complete to every later reader.
+        ok = (std::fclose(f) == 0) && ok;
         if (!ok)
         {
             std::remove(path.c_str());
@@ -253,6 +334,7 @@ namespace world::terrain
         tile->hasTerrain = hasTerrain != 0;
         tile->isGlobalWmo = globalWmo != 0;
         tile->hasLiquid = hasLiquid != 0;
+        ok = ok && TerrainGridSizesOk(*tile);
 
         uint32_t nModels = 0;
         ok = ok && RPod(f, nModels) && nModels <= MAX_MODELS;
@@ -278,7 +360,7 @@ namespace world::terrain
             if (kind == uint8_t(ModelKind::Wmo))
             {
                 uint32_t rootId = 0, nGroups = 0;
-                ok = RPod(f, rootId) && RPod(f, nGroups) && nGroups <= MAX_MODELS;
+                ok = RPod(f, rootId) && RPod(f, nGroups) && nGroups <= MAX_GROUPS;
                 std::vector<WmoModel::Group> groups(ok ? nGroups : 0);
                 for (uint32_t g = 0; ok && g < nGroups; ++g)
                 {
@@ -288,11 +370,12 @@ namespace world::terrain
                 std::vector<uint16_t> triGroup;
                 ok = ok && RVec(f, soup.verts) && RVec(f, soup.tris) &&
                      RVec(f, triGroup) && RVec(f, nodes) &&
-                     triGroup.size() == soup.tris.size();
+                     triGroup.size() == soup.tris.size() && soup.IndicesValid();
+
+                Bvh bvh;
+                ok = ok && bvh.Adopt(std::move(nodes), soup.tris.size());
                 if (ok)
                 {
-                    Bvh bvh;
-                    bvh.Adopt(std::move(nodes));
                     models[i] = std::make_shared<WmoModel>(std::move(soup),
                                                            std::move(triGroup),
                                                            std::move(groups), rootId,
@@ -301,11 +384,13 @@ namespace world::terrain
             }
             else if (kind == uint8_t(ModelKind::Mesh))
             {
-                ok = RVec(f, soup.verts) && RVec(f, soup.tris) && RVec(f, nodes);
+                ok = RVec(f, soup.verts) && RVec(f, soup.tris) && RVec(f, nodes) &&
+                     soup.IndicesValid();
+
+                Bvh bvh;
+                ok = ok && bvh.Adopt(std::move(nodes), soup.tris.size());
                 if (ok)
                 {
-                    Bvh bvh;
-                    bvh.Adopt(std::move(nodes));
                     models[i] = std::make_shared<CollisionModel>(std::move(soup),
                                                                  std::move(bvh));
                 }
@@ -322,11 +407,21 @@ namespace world::terrain
         {
             StaticInstance inst;
             uint32_t idx = 0;
+            float scale = 1.0f;
             ok = RPod(f, inst.xf.pos) && RArray(f, inst.xf.rot.m) &&
-                 RPod(f, inst.xf.scale) && RPod(f, inst.worldBounds.lo) &&
-                 RPod(f, inst.worldBounds.hi) && RPod(f, idx) && RPod(f, inst.adtId);
+                 RPod(f, scale) && RPod(f, inst.worldBounds.lo) &&
+                 RPod(f, inst.worldBounds.hi) && RPod(f, idx) && RPod(f, inst.adtId) &&
+                 inst.xf.pos.isFinite() && inst.worldBounds.lo.isFinite() &&
+                 inst.worldBounds.hi.isFinite() && RotationOk(inst.xf.rot);
             if (ok)
             {
+                // Through the CLAMPING constructor, never by assigning the field. The
+                // comment on that constructor says a non-positive or non-finite scale
+                // is screened once, where a model is placed -- and this is the one place
+                // a scale enters the server without passing through it. A zero read off
+                // disk divides to infinity in worldToLocal, and every ray then misses
+                // the model instead of failing.
+                inst.xf = Transform(inst.xf.pos, inst.xf.rot, scale);
                 if (idx < models.size())
                 {
                     inst.model = models[idx];

--- a/src/shared/terrain/WmoModel.cpp
+++ b/src/shared/terrain/WmoModel.cpp
@@ -81,13 +81,31 @@ namespace world::terrain
                 continue;
             }
 
-            const float txf = (p.x - lq.corner.x) / LIQUID_TILE_SIZE;
-            const float tyf = (p.y - lq.corner.y) / LIQUID_TILE_SIZE;
-            const int tx = int(txf), ty = int(tyf);
-            if (txf < 0.f || tyf < 0.f || tx >= int(lq.tilesX) || ty >= int(lq.tilesY))
+            // H() below indexes the corner grid unchecked, up to (tx+1, ty+1). That is
+            // only in bounds if the heights really are (tilesX+1) x (tilesY+1) -- so a
+            // group whose counts disagree with its vector is dropped rather than
+            // sampled off the end. The serializer screens this on load too; here is
+            // where the read would happen.
+            if (lq.heights.size() != size_t(lq.tilesX + 1) * size_t(lq.tilesY + 1))
             {
                 continue;
             }
+
+            const float txf = (p.x - lq.corner.x) / LIQUID_TILE_SIZE;
+            const float tyf = (p.y - lq.corner.y) / LIQUID_TILE_SIZE;
+            // Stated POSITIVELY so a NaN falls out here rather than through: every
+            // comparison against a NaN is false, so "not outside" would have let one
+            // reach the conversion below.
+            if (!(txf >= 0.f && txf < float(lq.tilesX)) ||
+                !(tyf >= 0.f && tyf < float(lq.tilesY)))
+            {
+                continue;
+            }
+            // Ranged in FLOAT before the conversion, not after: int(txf) for a point far
+            // outside the group -- which is most of the model, most of the time -- is a
+            // conversion that does not fit, and that is undefined, not a big number.
+            // Non-negative and in range here, so the truncation floors.
+            const int tx = int(txf), ty = int(tyf);
 
             const size_t fi = size_t(tx) + size_t(ty) * lq.tilesX;
             if (fi < lq.flags.size() && (lq.flags[fi] & 0x0F) == 0x0F)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ set(SRC_GRP_TESTS
     NavBinningTest.cpp
     DynamicCollisionTest.cpp
     PlacementTest.cpp
+    GeometryMathTest.cpp
     LFGLogicTest.cpp
     # Compiled in, not linked from `game`: game.lib pulls the whole server, down to the
     # database globals that only mangosd defines. These two know nothing of it.

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ set(SRC_GRP_TESTS
     NavBinningTest.cpp
     DynamicCollisionTest.cpp
     PlacementTest.cpp
+    DataIntegrityTest.cpp
     LFGLogicTest.cpp
     # Compiled in, not linked from `game`: game.lib pulls the whole server, down to the
     # database globals that only mangosd defines. These two know nothing of it.
@@ -82,6 +83,7 @@ target_link_libraries(mangos_tests
     PRIVATE
         proto
         shared
+        dataintegrity
         extractor_client
         extractor_data
         Threads::Threads

--- a/src/tests/ClientParserTest.cpp
+++ b/src/tests/ClientParserTest.cpp
@@ -483,9 +483,44 @@ TEST(AdtStopsOnTruncatedChunk)
     adt.U32(0x7FFFFFFF);
     adt.Pad(16);
 
+    // REJECTED, not merely stopped. A chunk whose size runs past the end of the buffer
+    // is a structurally broken file, which is the one thing ParseAdt's contract says it
+    // returns false for; this case used to be accepted as an empty tile. It matters
+    // where the truncation lands AFTER some MCNKs: v9/v8 are allocated whole and zeroed
+    // by the first one, so every cell the parse never reached comes back as ground at
+    // sea level -- and hasTerrain is true, so nothing downstream doubts it.
+    AdtData d;
+    CHECK(!ParseAdt(adt.b, d));
+    CHECK(!d.hasTerrain);
+    CHECK_EQ(d.chunksFilled, uint32_t(0));
+}
+
+TEST(AdtCountsTheChunksItFilled)
+{
+    // The baker requires all 256; a real 3.3.5a ADT has them. The parser only counts,
+    // because it is also handed the deliberately minimal ADTs above.
+    float mcvt[145];
+    FillRamp(mcvt, 0.f);
+
+    Blob adt;
+    PutChunk(adt, "MCNK", MakeMcnk(1, 2, 0.f, 0, 0, mcvt));
+    PutChunk(adt, "MCNK", MakeMcnk(3, 4, 0.f, 0, 0, mcvt));
+
     AdtData d;
     REQUIRE(ParseAdt(adt.b, d));
-    CHECK(!d.hasTerrain);
+    CHECK(d.hasTerrain);
+    CHECK_EQ(d.chunksFilled, uint32_t(2));
+
+    // A chunk header shorter than the 128 bytes the fields reach into is not read at
+    // all: the last chunk in a buffer is the one that would walk off the end.
+    Blob stunted;
+    Blob tiny;
+    tiny.Pad(64);
+    PutChunk(stunted, "MCNK", tiny);
+
+    AdtData s;
+    REQUIRE(ParseAdt(stunted.b, s));
+    CHECK_EQ(s.chunksFilled, uint32_t(0));
 }
 
 TEST(WdtGridAndGlobalWmo)

--- a/src/tests/DataIntegrityTest.cpp
+++ b/src/tests/DataIntegrityTest.cpp
@@ -1,0 +1,235 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+// The digests are checked against the PUBLISHED vectors, not against a second run of the
+// same code -- a hash agreeing with itself proves nothing at all, and this one is written
+// into a file that another tool (sha256sum) has to agree with.
+
+#include "TestHarness.h"
+
+#include "DataIntegrity/DataManifest.h"
+#include "DataIntegrity/Sha256.h"
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <process.h>
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+using namespace MaNGOS::DataIntegrity;
+
+namespace
+{
+    unsigned long TestPid()
+    {
+#ifdef _WIN32
+        return static_cast<unsigned long>(::GetCurrentProcessId());
+#else
+        return static_cast<unsigned long>(::getpid());
+#endif
+    }
+
+    std::string TempRoot(const char* leaf)
+    {
+        const char* dir = std::getenv("TMPDIR");
+        if (!dir)
+        {
+            dir = std::getenv("TEMP");
+        }
+        if (!dir)
+        {
+            dir = "/tmp";
+        }
+        return std::string(dir) + "/mangos_manifest_" + std::to_string(TestPid()) + "_" +
+               leaf;
+    }
+
+    /// A data directory that cleans itself up however the test leaves.
+    struct ScopedTree
+    {
+        std::string root;
+
+        explicit ScopedTree(const char* leaf) : root(TempRoot(leaf))
+        {
+            std::error_code ec;
+            std::filesystem::remove_all(root, ec);
+            std::filesystem::create_directories(root + "/tiles", ec);
+            std::filesystem::create_directories(root + "/dbc", ec);
+        }
+
+        ~ScopedTree()
+        {
+            std::error_code ec;
+            std::filesystem::remove_all(root, ec);
+        }
+
+        void Put(const std::string& relative, const std::string& bytes) const
+        {
+            std::ofstream out(root + "/" + relative, std::ios::binary | std::ios::trunc);
+            out.write(bytes.data(), std::streamsize(bytes.size()));
+        }
+
+        std::string Read(const std::string& relative) const
+        {
+            std::ifstream in(root + "/" + relative, std::ios::binary);
+            return std::string((std::istreambuf_iterator<char>(in)),
+                               std::istreambuf_iterator<char>());
+        }
+    };
+}
+
+TEST(Sha256MatchesThePublishedVectors)
+{
+    // FIPS 180-4 / NIST examples.
+    CHECK_STR(Sha256Hex("", 0),
+              "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    CHECK_STR(Sha256Hex("abc", 3),
+              "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+
+    const std::string abcdef =
+        "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
+    CHECK_STR(Sha256Hex(abcdef.data(), abcdef.size()),
+              "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1");
+
+    // A million 'a'. Slow enough to matter only here, and the one vector that exercises
+    // the block loop rather than a single padded block.
+    const std::string million(1000000, 'a');
+    CHECK_STR(Sha256Hex(million.data(), million.size()),
+              "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0");
+}
+
+TEST(Sha256OfAFileMatchesTheSameBytesInMemory)
+{
+    ScopedTree tree("filehash");
+    tree.Put("tiles/one.tile", "abc");
+
+    const auto hex = Sha256File(tree.root + "/tiles/one.tile");
+    REQUIRE(hex.has_value());
+    CHECK_STR(*hex, "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+
+    CHECK(!Sha256File(tree.root + "/tiles/absent.tile").has_value());
+}
+
+TEST(ManifestRoundTripsAndIsSha256sumShaped)
+{
+    ScopedTree tree("roundtrip");
+    tree.Put("tiles/t_0_32_32.tile", "abc");
+    tree.Put("dbc/Map.dbc", "");
+
+    REQUIRE(WriteManifest(tree.root, {"tiles", "dbc"}));
+
+    // `<64 hex><two spaces><path>`, LF, sorted -- the layout `sha256sum -c` reads. A
+    // header or a comment would be friendlier to us and unreadable to it.
+    const std::string text = tree.Read(MANIFEST_FILE_NAME);
+    CHECK(text.find('\r') == std::string::npos);
+    CHECK(text.find(
+              "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  dbc/Map.dbc\n") == 0);
+    CHECK(text.find(
+              "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad  tiles/t_0_32_32.tile\n") !=
+          std::string::npos);
+
+    std::vector<ManifestEntry> entries;
+    REQUIRE(ReadManifest(tree.root + "/" + MANIFEST_FILE_NAME, entries));
+    CHECK_EQ(entries.size(), size_t(2));
+    CHECK_STR(entries[0].path, "dbc/Map.dbc");
+    CHECK_STR(entries[1].path, "tiles/t_0_32_32.tile");
+
+    const VerifyResult ok = VerifyManifest(tree.root);
+    CHECK(ok.Ok());
+    CHECK_EQ(ok.verified, size_t(2));
+    CHECK_EQ(ok.changed, size_t(0));
+}
+
+TEST(ManifestNoticesEveryWayADataSetGoesWrong)
+{
+    ScopedTree tree("tamper");
+    tree.Put("tiles/a.tile", "aaaa");
+    tree.Put("tiles/b.tile", "bbbb");
+    tree.Put("dbc/Map.dbc", "cccc");
+    REQUIRE(WriteManifest(tree.root, {"tiles", "dbc"}));
+
+    // One byte, which is the case the whole thing exists for: a tile that still has its
+    // magic, its version and its length, and is not the tile that was baked.
+    tree.Put("tiles/a.tile", "aaab");
+
+    std::error_code ec;
+    std::filesystem::remove(tree.root + "/tiles/b.tile", ec);
+
+    const VerifyResult bad = VerifyManifest(tree.root);
+    CHECK(!bad.Ok());
+    CHECK_EQ(bad.listed, size_t(3));
+    CHECK_EQ(bad.verified, size_t(1));
+    CHECK_EQ(bad.changed, size_t(1));
+    CHECK_EQ(bad.missing, size_t(1));
+    CHECK(!bad.examples.empty());
+
+    // A file the manifest never listed is not damage: a data directory holds things the
+    // baker did not write, and calling those corruption would make the check unusable
+    // exactly where it is needed.
+    tree.Put("tiles/a.tile", "aaaa");
+    std::filesystem::remove(tree.root + "/tiles/b.tile", ec);
+    tree.Put("tiles/b.tile", "bbbb");
+    tree.Put("tiles/mine.txt", "not from the baker");
+
+    const VerifyResult restored = VerifyManifest(tree.root);
+    CHECK(restored.Ok());
+    CHECK_EQ(restored.verified, size_t(3));
+}
+
+TEST(ManifestIsAbsentRatherThanEmptyWhenThereIsNone)
+{
+    ScopedTree tree("nomanifest");
+    tree.Put("tiles/a.tile", "aaaa");
+
+    const VerifyResult none = VerifyManifest(tree.root);
+    CHECK(!none.manifestFound);
+    CHECK(!none.Ok());              // not verified, which is not the same as verified bad
+    CHECK_EQ(none.listed, size_t(0));
+}
+
+TEST(ManifestRejectsALineItDidNotWrite)
+{
+    ScopedTree tree("badline");
+    tree.Put("tiles/a.tile", "aaaa");
+    REQUIRE(WriteManifest(tree.root, {"tiles"}));
+
+    // Truncated digest: accepted, this would compare a 32-character prefix against a
+    // 64-character one and report every file as changed.
+    tree.Put(MANIFEST_FILE_NAME, "deadbeef  tiles/a.tile\n");
+    std::vector<ManifestEntry> entries;
+    CHECK(!ReadManifest(tree.root + "/" + MANIFEST_FILE_NAME, entries));
+
+    const VerifyResult bad = VerifyManifest(tree.root);
+    CHECK(bad.manifestFound);
+    CHECK(!bad.manifestReadable);
+    CHECK(!bad.Ok());
+}

--- a/src/tests/GeometryMathTest.cpp
+++ b/src/tests/GeometryMathTest.cpp
@@ -1,0 +1,156 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+// The degenerate inputs the geometry primitives are actually handed at runtime, and
+// which no ordinary play ever produces: a zero-length direction, a zero quaternion,
+// an orientation a client reported as NaN, an empty bounding box folded into an
+// accumulator. Every one of them used to answer with NaN or infinity, and NaN is the
+// worst possible failure here because every comparison against it is false -- nothing
+// reports an error, a ray simply misses and a creature simply stands in the wrong place.
+
+#include "TestHarness.h"
+
+#include "Geometry/GeometryMath.h"
+#include "Geometry/Quat.h"
+#include "Geometry/Shapes.h"
+#include "Geometry/Vector3.h"
+
+#include <cmath>
+#include <limits>
+
+static const float kNan = std::numeric_limits<float>::quiet_NaN();
+static const float kInf = std::numeric_limits<float>::infinity();
+
+static bool Near(float a, float b, float tol = 1e-5f)
+{
+    return std::fabs(a - b) < tol;
+}
+
+TEST(GeometryMath_WrapKeepsAnOrdinaryOrientationExactly)
+{
+    const float twoPi = 2.0f * Geometry::pif();
+
+    CHECK(Near(Geometry::wrap(1.0f, 0.0f, twoPi), 1.0f));
+    CHECK(Near(Geometry::wrap(0.0f, 0.0f, twoPi), 0.0f));
+    CHECK(Near(Geometry::wrap(-1.0f, 0.0f, twoPi), twoPi - 1.0f));
+    CHECK(Near(Geometry::wrap(twoPi + 1.0f, 0.0f, twoPi), 1.0f));
+}
+
+TEST(GeometryMath_WrapSurvivesWhatAClientCanSend)
+{
+    // MoveSpline normalises the orientation the CLIENT reports, so these are reachable
+    // from a movement packet. The old form computed int(floor(x)) on the quotient:
+    // undefined behaviour for a NaN and for anything past 2^31 intervals, not merely a
+    // wrong angle. Nothing here asserts a value for the huge case -- the cancellation
+    // makes it meaningless -- only that it is a finite number and not a trap.
+    const float twoPi = 2.0f * Geometry::pif();
+
+    CHECK(Geometry::wrap(kNan, 0.0f, twoPi) == 0.0f);
+    CHECK(Geometry::wrap(kInf, 0.0f, twoPi) == 0.0f);
+    CHECK(Geometry::wrap(-kInf, 0.0f, twoPi) == 0.0f);
+    CHECK(std::isfinite(Geometry::wrap(1e30f, 0.0f, twoPi)));
+    CHECK(std::isfinite(Geometry::wrap(-1e30f, 0.0f, twoPi)));
+
+    // A degenerate interval has no half-open range to land in; it fails closed to lo.
+    CHECK(Geometry::wrap(3.0f, 1.0f, 1.0f) == 1.0f);
+    CHECK(Geometry::wrap(3.0f, 1.0f, 0.0f) == 1.0f);
+}
+
+TEST(Geometry_ZeroVectorHasNoDirection)
+{
+    const Geometry::Vector3 zero(0.0f, 0.0f, 0.0f);
+    const Geometry::Vector3 dir = zero.direction();
+
+    CHECK(dir.isFinite());
+    CHECK(dir.isZero());
+
+    const Geometry::Vector3 down(0.0f, 0.0f, -3.0f);
+    CHECK(down.unit().isUnit());
+    CHECK(Near(down.unit().z, -1.0f));
+
+    const Geometry::Vector3 broken(kNan, 0.0f, 0.0f);
+    CHECK(broken.direction().isFinite());
+}
+
+TEST(Geometry_ZeroQuaternionUnitizesToTheIdentity)
+{
+    Geometry::Quat zero(0.0f, 0.0f, 0.0f, 0.0f);
+    zero.unitize();
+
+    CHECK(zero.isUnit());
+    CHECK(Near(zero.w, 1.0f));
+    CHECK(Near(zero.imag().x, 0.0f));
+
+    Geometry::Quat scaled(0.0f, 0.0f, 2.0f, 2.0f);
+    scaled.unitize();
+    CHECK(scaled.isUnit());
+}
+
+TEST(Geometry_AnEmptyBoxDoesNotPoisonAnAccumulator)
+{
+    // The empty box is lo = +max, hi = -max. Folding one into an accumulator used to
+    // widen it to the whole float range, whose extent overflows to infinity -- after
+    // which every SAH split of the BVH costs the same and the tree stops separating.
+    Geometry::Aabb acc;
+    CHECK(!acc.valid());
+
+    acc.expand(Geometry::Vector3(0.0f, 0.0f, 0.0f));
+    acc.expand(Geometry::Vector3(10.0f, 4.0f, 2.0f));
+    CHECK(acc.valid());
+
+    acc.expand(Geometry::Aabb{});
+    CHECK(acc.valid());
+    CHECK(Near(acc.lo.x, 0.0f));
+    CHECK(Near(acc.hi.x, 10.0f));
+    CHECK(std::isfinite(acc.hi.z - acc.lo.z));
+
+    // A box that has seen a point on no axis is valid on none of them.
+    Geometry::Aabb empty;
+    CHECK(!empty.valid());
+}
+
+TEST(Geometry_ADegenerateRayMatchesNoBox)
+{
+    // A direction of zero length normalises to NaN, and 1/NaN is NaN. Every comparison
+    // in the slab test against a NaN is false, so the axis used to be dropped silently
+    // and the node accepted -- for every origin, however far outside the box.
+    Geometry::Aabb box;
+    box.expand(Geometry::Vector3(0.0f, 0.0f, 0.0f));
+    box.expand(Geometry::Vector3(10.0f, 10.0f, 10.0f));
+
+    const Geometry::Vector3 farAway(1000.0f, 1000.0f, 1000.0f);
+    const Geometry::Vector3 nanInvDir(kNan, kNan, kNan);
+    CHECK(!box.intersectsRay(farAway, nanInvDir, 10000.0f));
+
+    // A ray straight down THROUGH the box still hits: two of its reciprocals are
+    // infinite, and the padding must keep answering yes.
+    const Geometry::Vector3 above(5.0f, 5.0f, 100.0f);
+    const Geometry::Vector3 downInvDir(kInf, kInf, -1.0f);
+    CHECK(box.intersectsRay(above, downInvDir, 200.0f));
+
+    // The same ray beside the box, on an axis whose reciprocal is infinite, misses.
+    const Geometry::Vector3 beside(50.0f, 5.0f, 100.0f);
+    CHECK(!box.intersectsRay(beside, downInvDir, 200.0f));
+}

--- a/src/tests/ModelMapTest.cpp
+++ b/src/tests/ModelMapTest.cpp
@@ -191,3 +191,29 @@ TEST(ModelMap_WithoutASourceADisplayIdNamesNoTerrainAtAll)
 
     FusedTerrain::SetTileDir(saved);
 }
+
+// The `disables` table can switch a map's baked collision off per category. The engine
+// is told WHICH categories to gather, never why, and the translation from a database row
+// lives in TerrainInfo -- so what is pinned here is that excluding a source removes only
+// that source's surfaces and leaves the rest of the gather intact.
+TEST(ModelMap_ExcludingBakedStaticsEmptiesAModelBackedMap)
+{
+    FusedTerrain hull(SHIP_TRANSPORTSHIP, HullSource());
+
+    const uint32_t noStatic =
+        FusedTerrain::SOURCE_ALL & ~uint32_t(FusedTerrain::SOURCE_STATIC);
+
+    // A model-backed map has nothing BUT baked statics, so dropping them leaves nothing
+    // at all -- which is exactly what a map with collision height disabled is asserting.
+    CHECK(!hull.ColumnAt(5.f, 5.f, 8.f, -10.f).Empty());
+    CHECK(hull.ColumnAt(5.f, 5.f, 8.f, -10.f, nullptr, 0, noStatic).Empty());
+
+    // Dropping WMO liquid instead leaves the floor standing: the two are separate
+    // categories, and the flags in `disables` are separate bits for the same reason.
+    const uint32_t noStaticLiquid =
+        FusedTerrain::SOURCE_ALL & ~uint32_t(FusedTerrain::SOURCE_STATIC_LIQUID);
+    auto z = hull.ColumnAt(5.f, 5.f, 8.f, -10.f, nullptr, 0, noStaticLiquid)
+                 .HighestSolidAtOrBelow(6.f);
+    REQUIRE(z.has_value());
+    CHECK(Approx(*z, 5.f));
+}

--- a/src/tests/PlacementTest.cpp
+++ b/src/tests/PlacementTest.cpp
@@ -126,6 +126,22 @@ TEST(Placement_NeitherEmissaryHasTheOtherBehindIt)
     CHECK(!ArathorEmissary().IsInBack(ArathorEmissaryPair(), 5.0f, kPi));
 }
 
+TEST(Placement_AFullCircleArcSeesEveryDirection)
+{
+    // The arc is a WIDTH, not a direction, so it must not be wrapped into [0, 2*PI):
+    // a full circle wrapped to zero, halved, and matched only a target dead ahead.
+    // The emissary is 1.5 degrees off dead ahead, so the difference does not show
+    // there -- it shows at the two ends of the range.
+    CHECK(ArathorEmissary().HasInArc(ArathorEmissaryPair(), 2.0f * kPi));
+    CHECK(ArathorEmissary().HasInArc(ArathorEmissaryPair(), 4.0f * kPi));
+    CHECK(!ArathorEmissary().HasInArc(ArathorEmissaryPair(), 0.0f));
+    CHECK(!ArathorEmissary().HasInArc(ArathorEmissaryPair(), -1.0f));
+
+    // IsInBack asks for the complement, so an arc of zero means "nothing is in front
+    // of me", and the emissary standing in plain sight was reported as behind.
+    CHECK(!ArathorEmissary().IsInBack(ArathorEmissaryPair(), 5.0f, 0.0f));
+}
+
 TEST(Placement_StormwindResidentsAreOutOfInteractionRange)
 {
     // Turner to Gallina is 16.07 centre to centre: past INTERACTION_DISTANCE (5 yards),
@@ -161,6 +177,36 @@ TEST(Placement_TheSameStormwindSpotOnKalimdorIsUnreachable)
     CHECK(std::isinf(inStormwind.DistanceTo(inKalimdor)));
     CHECK(!inStormwind.WithinDist(inKalimdor, 1000.0f));
     CHECK(!inStormwind.HasInArc(inKalimdor, 2.0f * kPi - 0.001f));
+}
+
+TEST(Placement_AnItemInABagIsNowhereAtAll)
+{
+    // A default Placement is what an Item has: no frame. Measured against a bare
+    // coordinate it used to answer as though it stood at the origin of a map it is
+    // not on -- 8843 yards from Stormwind rather than nowhere.
+    const Geometry::Placement carried;
+    const Geometry::Vector3 stormwind(-8840.63f, 652.959f, 97.1184f);
+
+    CHECK(!carried.IsPlaced());
+    CHECK(std::isinf(carried.DistanceTo(stormwind)));
+    CHECK(std::isinf(carried.DistanceTo(Geometry::Vector2(-8840.63f, 652.959f))));
+    CHECK(!carried.WithinDist(stormwind, 100000.0f));
+    CHECK(!carried.WithinRange(stormwind, 0.0f, 100000.0f));
+    CHECK(!carried.WithinBox(stormwind, Geometry::Vector3(100000.0f, 100000.0f, 100000.0f)));
+}
+
+TEST(Placement_ReachIsClosedAtItsOwnLimit)
+{
+    // Stormwind coordinates chosen so the separation is EXACTLY four yards in float:
+    // the point of the case is the comparison at the limit, and a real spawn pair
+    // whose distance is only approximately known cannot pin it.
+    const Geometry::Placement a = Spawn(-8840.0f, 650.0f, 97.0f, 0.0f, 0.0f);
+    const Geometry::Placement b = Spawn(-8836.0f, 650.0f, 97.0f, 0.0f, 0.0f);
+
+    CHECK(Approx(a.DistanceTo(b), 4.0f));
+    CHECK(a.WithinDist(b, 4.0f));            // exactly at reach counts as within
+    CHECK(!a.WithinDist(b, 3.999f));
+    CHECK(a.WithinRange(b, 0.0f, 4.0f));
 }
 
 TEST(Placement_TwoNaxxramasCopiesNeverSeeEachOther)

--- a/src/tests/TerrainModelTest.cpp
+++ b/src/tests/TerrainModelTest.cpp
@@ -336,3 +336,103 @@ TEST(WmoAreaInfoNamesTheGroupTheRayHit)
     REQUIRE(below.has_value());
     CHECK_EQ(below->groupId, uint32_t(111));
 }
+
+// A tile file is not a message from a peer, but it is still bytes from outside the
+// process, and the query path trusts them completely: Raycast pushes both children of
+// every node onto a stack sized from MAX_DEPTH, indexes the array with whatever it
+// popped, and reads a leaf's triangle run without a bounds test. All three are safe only
+// because Build cannot emit a node array that breaks them. A file can.
+TEST(BvhAdoptRejectsANodeArrayThatIsNotATree)
+{
+    std::mt19937 rng(0xBADF00D);
+    TriSoup soup = RandomSoup(rng, 200, 40.f);
+
+    Bvh built;
+    built.Build(soup);
+    const std::vector<Bvh::Node> good = built.Nodes();
+    REQUIRE(good.size() > 2);
+    REQUIRE(good[0].left >= 0);           // the root of this soup is not a leaf
+
+    {
+        Bvh bvh;
+        CHECK(bvh.Adopt(good, soup.tris.size()));
+        CHECK_EQ(bvh.NodeCount(), good.size());
+    }
+    {
+        // Empty is a legal tile: a model with no geometry.
+        Bvh bvh;
+        CHECK(bvh.Adopt({}, 0));
+        CHECK(bvh.Empty());
+    }
+    {
+        // A child that points at or behind its parent is a cycle, and the walk would
+        // never come back.
+        std::vector<Bvh::Node> nodes = good;
+        nodes[0].left = 0;
+        Bvh bvh;
+        CHECK(!bvh.Adopt(nodes, soup.tris.size()));
+        CHECK(bvh.Empty());
+    }
+    {
+        std::vector<Bvh::Node> nodes = good;
+        nodes[0].right = int32_t(nodes.size()) + 7;
+        Bvh bvh;
+        CHECK(!bvh.Adopt(nodes, soup.tris.size()));
+    }
+    {
+        // Both children the same node: not a tree, and the second visit is a second
+        // walk of the same subtree.
+        std::vector<Bvh::Node> nodes = good;
+        nodes[0].right = nodes[0].left;
+        Bvh bvh;
+        CHECK(!bvh.Adopt(nodes, soup.tris.size()));
+    }
+    {
+        // A leaf whose run reaches past the soup: an out-of-bounds read per ray.
+        std::vector<Bvh::Node> nodes = good;
+        for (Bvh::Node& n : nodes)
+        {
+            if (n.left < 0)
+            {
+                n.count = uint32_t(soup.tris.size()) + 4;
+                break;
+            }
+        }
+        Bvh bvh;
+        CHECK(!bvh.Adopt(nodes, soup.tris.size()));
+    }
+    {
+        // A node nothing points at is not part of the tree, and its depth is unknowable.
+        std::vector<Bvh::Node> nodes = good;
+        nodes.push_back(Bvh::Node{});
+        Bvh bvh;
+        CHECK(!bvh.Adopt(nodes, soup.tris.size()));
+    }
+}
+
+TEST(TriSoupRejectsATriangleThatNamesAVertexItDoesNotHave)
+{
+    TriSoup soup;
+    soup.verts = {{0, 0, 0}, {1, 0, 0}, {0, 1, 0}};
+    soup.tris = {{0, 1, 2}};
+    CHECK(soup.IndicesValid());
+
+    soup.tris.push_back({0, 1, 3});
+    CHECK(!soup.IndicesValid());
+
+    TriSoup empty;
+    CHECK(empty.IndicesValid());
+}
+
+TEST(TileIndexFloorsInsteadOfTruncating)
+{
+    // The map spans 64 tiles centred on 32, so world x = 0 is tile 32.
+    CHECK_EQ(TileIndex(0.f), 32);
+    CHECK_EQ(TileIndex(-1.f), 32);
+
+    // The 4.16-yard strip past the far corner, where the grid coordinate lands in
+    // (-1, 0). Truncating toward zero called it tile 0 -- the tile at the OPPOSITE
+    // edge of the map -- instead of the tile -1 that is off the map.
+    CHECK_EQ(TileIndex(17066.f), 0);
+    CHECK_EQ(TileIndex(17068.f), -1);
+}

--- a/src/tests/TileSerializerTest.cpp
+++ b/src/tests/TileSerializerTest.cpp
@@ -400,7 +400,10 @@ TEST(TileReaderRejectsCountsLargerThanTheFile)
     std::FILE* f = std::fopen(file.path.c_str(), "wb");
     REQUIRE(f != nullptr);
     const uint32_t magic = 0x32474E4D;  // "MNG2"
-    const uint32_t version = 1;
+    // Must track TileSerializer's VERSION. Leave it behind and the reader rejects this
+    // file on the version alone, the absurd count below is never reached, and the case
+    // goes green while testing nothing at all.
+    const uint32_t version = 2;
     const int32_t tx = 0, ty = 0;
     const uint8_t flags[2] = {1, 0};
     const uint32_t absurd = 0xFFFFFFFFu;

--- a/src/tools/extractor/CMakeLists.txt
+++ b/src/tools/extractor/CMakeLists.txt
@@ -150,6 +150,11 @@ target_compile_definitions(mangos-extractor
 target_link_libraries(mangos-extractor
     PRIVATE
         extractor_mpq
+        # The manifest the server verifies at start-up is written HERE, by the same code
+        # that reads it -- a second implementation of the format would be a second thing
+        # to keep in step. `dataintegrity` carries OpenSSL and nothing else, so this does
+        # not pull `shared` (and MySQL with it) into the baker.
+        dataintegrity
         # The baker threads its per-tile work; relying on another target's link line to
         # drag in the thread library is an accident, not a dependency.
         Threads::Threads

--- a/src/tools/extractor/Extractor.cpp
+++ b/src/tools/extractor/Extractor.cpp
@@ -39,6 +39,7 @@
 #include "stores/GameObjectDisplayInfoStore.hpp"
 #include "stores/MapDbcStore.hpp"
 #include "terrain/TileSerializer.hpp"
+#include "DataIntegrity/DataManifest.h"
 
 #include <algorithm>
 #include <chrono>
@@ -558,6 +559,40 @@ namespace
         return true;
     }
 
+    // Every file the server will read, hashed, so it can tell at start-up whether it is
+    // reading what was written here. Called on each path that FINISHES: a manifest over
+    // a bake that failed would certify the holes, which is the one thing worse than not
+    // having one.
+    //
+    // The whole data directory is walked every time, not just the part this run touched.
+    // A tiles-only run therefore re-lists the game-object models and the DBCs beside
+    // them -- if they are stale, that is what the set contains, and the manifest
+    // describes the set rather than the run.
+    bool WriteDataManifest(const std::string& dest)
+    {
+        namespace di = MaNGOS::DataIntegrity;
+
+        g_console.SetStage("manifest");
+        const bool ok = di::WriteManifest(
+            dest, {"dbc", "gomodels", "tiles", "mmaps"},
+            [](size_t done, size_t total, const std::string&)
+            {
+                g_console.SetCounts(done, total);
+                Tick();
+            });
+
+        if (ok)
+        {
+            g_console.Detail("manifest: " + dest + "/" + di::MANIFEST_FILE_NAME);
+        }
+        else
+        {
+            g_console.Error("manifest: FAILED to write " + dest + "/" +
+                            di::MANIFEST_FILE_NAME);
+        }
+        return ok;
+    }
+
     // One map's tiles. A map is either an ADT grid or a single global WMO; both end up
     // as the same payload, so the runtime has nothing to reconcile.
     //
@@ -793,7 +828,7 @@ int main(int argc, char** argv)
     if (!opt.dbc && !opt.tiles && !opt.goModels)
     {
         BakeVessels();
-        const bool ok = BakeNav(opt, tileDir);
+        const bool ok = BakeNav(opt, tileDir) && WriteDataManifest(opt.dest);
         g_console.SetStage("done");
         g_console.Progress(-1);
         g_console.Stop();
@@ -854,7 +889,7 @@ int main(int argc, char** argv)
     if (!opt.tiles && !opt.goModels)
     {
         BakeVessels();
-        const bool ok = BakeNav(opt, tileDir);
+        const bool ok = BakeNav(opt, tileDir) && WriteDataManifest(opt.dest);
         g_console.SetStage("done");
         g_console.Progress(-1);
         g_console.Stop();
@@ -893,7 +928,7 @@ int main(int argc, char** argv)
 
     if (!opt.tiles)
     {
-        const bool ok = BakeNav(opt, tileDir);
+        const bool ok = BakeNav(opt, tileDir) && WriteDataManifest(opt.dest);
         g_console.SetStage("done");
         g_console.Progress(-1);
         g_console.Stop();
@@ -931,6 +966,12 @@ int main(int argc, char** argv)
                       "bake INCOMPLETE: %d tile(s) failed; the data set has holes",
                       tileFailures);
         g_console.Error(msg);
+        g_console.Stop();
+        return 1;
+    }
+
+    if (!WriteDataManifest(opt.dest))
+    {
         g_console.Stop();
         return 1;
     }

--- a/src/tools/extractor/Extractor.cpp
+++ b/src/tools/extractor/Extractor.cpp
@@ -560,28 +560,40 @@ namespace
 
     // One map's tiles. A map is either an ADT grid or a single global WMO; both end up
     // as the same payload, so the runtime has nothing to reconcile.
-    void BakeMap(MpqTileSource& source, uint32_t mapId, const std::string& name,
-                 const std::string& dest)
+    //
+    // @return how many tiles this map FAILED to bake. A failure that only reaches the
+    // log is a failure nobody acts on: the install script deletes the previous data
+    // before running this, and then reads the exit status as "the extraction is
+    // complete". A map missing half its tiles must not exit 0.
+    int BakeMap(MpqTileSource& source, uint32_t mapId, const std::string& name,
+                const std::string& dest)
     {
         const WdtData* wdt = source.Wdt(mapId);
         if (!wdt)
         {
-            return;
+            // Map.dbc lists identities that ship no WDT at all; that is not a failure.
+            return 0;
         }
 
         if (!wdt->HasAnyAdt())
         {
-            auto tile = source.Load(mapId, 0, 0);
-            if (tile && tile->isGlobalWmo)
+            // Asked of the WDT, not of the tile that just failed to load: "the load
+            // returned nothing" and "this map declares no global WMO" are the same
+            // value, and inferring one from the other hides exactly the failure this
+            // count exists to report.
+            if (!wdt->hasGlobalWmo)
             {
-                const bool ok =
-                    WriteTile(*tile, dest + "/" + GlobalWmoFileName(mapId));
-                char msg[256];
-                std::snprintf(msg, sizeof(msg), "  map %4u %-24s global WMO %s", mapId,
-                              name.c_str(), ok ? "ok" : "FAILED");
-                if (ok) { g_console.Detail(msg); } else { g_console.Error(msg); }
+                return 0;
             }
-            return;
+
+            auto tile = source.Load(mapId, 0, 0);
+            const bool ok = tile && tile->isGlobalWmo &&
+                            WriteTile(*tile, dest + "/" + GlobalWmoFileName(mapId));
+            char msg[256];
+            std::snprintf(msg, sizeof(msg), "  map %4u %-24s global WMO %s", mapId,
+                          name.c_str(), ok ? "ok" : "FAILED");
+            if (ok) { g_console.Detail(msg); } else { g_console.Error(msg); }
+            return ok ? 0 : 1;
         }
 
         size_t expected = 0;
@@ -624,6 +636,7 @@ namespace
         std::snprintf(msg, sizeof(msg), "  map %4u %-24s %5d tiles%s", mapId,
                       name.c_str(), written, failed ? " (SOME FAILED)" : "");
         if (failed) { g_console.Warn(msg); } else { g_console.Detail(msg); }
+        return failed;
     }
 }
 
@@ -891,17 +904,33 @@ int main(int argc, char** argv)
     MpqTileSource source(mpq, &maps, &liquids);
     g_console.Log("tiles -> " + tileDir);
 
+    int tileFailures = 0;
     for (const auto& entry : maps.All())
     {
         if (opt.mapFilter >= 0 && uint32_t(opt.mapFilter) != entry.first)
         {
             continue;
         }
-        BakeMap(source, entry.first, entry.second, tileDir);
+        tileFailures += BakeMap(source, entry.first, entry.second, tileDir);
     }
 
     if (!BakeNav(opt, tileDir))
     {
+        g_console.Stop();
+        return 1;
+    }
+
+    // The nav bake enumerates the tiles that WERE written, so it succeeds over a partial
+    // set and cannot report this on its own. Say so here, and exit non-zero: the install
+    // script removes the previous data before this runs and treats 0 as a complete
+    // extraction, so a silent partial bake leaves a server with holes in its world.
+    if (tileFailures > 0)
+    {
+        char msg[128];
+        std::snprintf(msg, sizeof(msg),
+                      "bake INCOMPLETE: %d tile(s) failed; the data set has holes",
+                      tileFailures);
+        g_console.Error(msg);
         g_console.Stop();
         return 1;
     }

--- a/src/tools/extractor/client/AdtParser.cpp
+++ b/src/tools/extractor/client/AdtParser.cpp
@@ -1,5 +1,8 @@
 #include "AdtParser.hpp"
 
+#include <algorithm>
+#include <array>
+
 namespace world::terrain
 {
     namespace
@@ -19,6 +22,7 @@ namespace world::terrain
         constexpr size_t MCNK_OFS_MCLQ = 0x60;
         constexpr size_t MCNK_SIZE_MCLQ = 0x64;
         constexpr size_t MCNK_POS_Z = 0x70;
+        constexpr uint32_t MCNK_HEADER = 128;
 
         constexpr uint32_t MCNK_FLAG_RIVER = 1u << 2;
         constexpr uint32_t MCNK_FLAG_OCEAN = 1u << 3;
@@ -41,15 +45,25 @@ namespace world::terrain
             out.liquidNoLight.assign(size_t(ADT_GRID) * ADT_GRID, 0);
         }
 
-        void ReadMcnk(const uint8_t* mcnk, uint32_t mcnkSize, AdtData& out)
+        /// @return the linear chunk this filled, or -1 when it is not usable.
+        int ReadMcnk(const uint8_t* mcnk, uint32_t mcnkSize, AdtData& out)
         {
+            // The header fields read below reach 0x74. Without this a chunk whose SIZE
+            // says less than a header walks off the end of the file -- and the chunk
+            // that does it is the last one in the buffer, where there is nothing after
+            // it to absorb the read.
+            if (mcnkSize < MCNK_HEADER)
+            {
+                return -1;
+            }
+
             const uint8_t* h = mcnk + 8;
             const uint32_t flags = RdU32(h + MCNK_FLAGS);
             const uint32_t ix = RdU32(h + MCNK_INDEX_X);
             const uint32_t iy = RdU32(h + MCNK_INDEX_Y);
             if (ix > 15 || iy > 15)
             {
-                return;
+                return -1;
             }
 
             const uint32_t offsMcvt = RdU32(h + MCNK_OFS_MCVT);
@@ -61,7 +75,16 @@ namespace world::terrain
             out.holes[iy * ADT_CHUNKS + ix] = static_cast<uint16_t>(RdU32(h + MCNK_HOLES) & 0xFFFF);
             out.areaIds[iy * ADT_CHUNKS + ix] = static_cast<uint16_t>(RdU32(h + MCNK_AREA_ID) & 0xFFFF);
 
-            if (offsMcvt && offsMcvt + 8 + 145 * 4 <= span)
+            // No MCVT, or one that does not fit, means this chunk contributes NO heights.
+            // Reporting it as filled anyway is worse than reporting nothing: v9/v8 were
+            // zeroed for the whole tile before the walk, so the chunk's 8x8 cells come
+            // back as flat ground at 0.0 -- and the count that decides whether the tile
+            // is written would have said the map square was read.
+            if (!offsMcvt || offsMcvt + 8 + 145 * 4 > span)
+            {
+                return -1;
+            }
+
             {
                 // MCVT is 145 floats: 9 V9 corners then 8 V8 centres, per row.
                 const uint8_t* hm = mcnk + offsMcvt + 8;
@@ -91,7 +114,7 @@ namespace world::terrain
             constexpr uint32_t MCLQ_BYTES = 8 + 81 * 8 + 64;
             if (!offsMclq || sizeMclq <= 8 || offsMclq + 8 + MCLQ_BYTES > span)
             {
-                return;
+                return int(iy) * ADT_CHUNKS + int(ix);   // heights are in; no MCLQ here
             }
 
             const uint8_t* lq = mcnk + offsMclq + 8;
@@ -147,6 +170,8 @@ namespace world::terrain
                     out.liquidDark[idx] = (cellFlags & MCLQ_DARK) ? 1 : 0;
                 }
             }
+
+            return int(iy) * ADT_CHUNKS + int(ix);
         }
 
         // MH2O: 256 SMLiquidChunk headers, one per MCNK in IndexY-major order, followed
@@ -275,6 +300,9 @@ namespace world::terrain
         uint32_t mh2oSize = 0;
 
         bool sawMcnk = false;
+        bool truncated = false;
+        std::array<bool, size_t(ADT_CHUNKS) * ADT_CHUNKS> filled{};
+
         size_t pos = 0;
         while (pos + 8 <= size)
         {
@@ -283,6 +311,7 @@ namespace world::terrain
             const uint8_t* body = data + pos + 8;
             if (pos + 8 + csize > size)
             {
+                truncated = true;
                 break;
             }
 
@@ -296,7 +325,11 @@ namespace world::terrain
                     out.areaIds.fill(0);
                     sawMcnk = true;
                 }
-                ReadMcnk(tag, csize, out);
+                const int chunk = ReadMcnk(tag, csize, out);
+                if (chunk >= 0)
+                {
+                    filled[size_t(chunk)] = true;
+                }
             }
             else if (TagIs(tag, "MH2O"))
             {
@@ -354,6 +387,21 @@ namespace world::terrain
             out.m2Names = ResolveNames(mmdx, mmdxSize, mmid, mmidSize);
         }
 
+        // A chunk that runs past the end of the buffer is a broken file, and what it
+        // leaves behind is worse than nothing: v9/v8 are allocated whole and zeroed by
+        // the first MCNK, so every cell the parse never reached reads back as ground at
+        // sea level -- authoritative, under a mountain, with nothing reporting a problem.
+        if (truncated)
+        {
+            out = AdtData{};
+            return false;
+        }
+
+        // A real 3.3.5a ADT carries all 256 MCNKs. Reported rather than enforced here,
+        // because this parser is also handed deliberately minimal ADTs (see
+        // ClientParserTest) and a chunk count is not the parser's business to police.
+        // The baker is what must refuse a hole-ridden tile -- see MpqTileSource.
+        out.chunksFilled = uint32_t(std::count(filled.begin(), filled.end(), true));
         out.hasTerrain = sawMcnk;
         return true;
     }

--- a/src/tools/extractor/client/AdtParser.hpp
+++ b/src/tools/extractor/client/AdtParser.hpp
@@ -25,6 +25,11 @@ namespace world::terrain
     struct AdtData
     {
         bool hasTerrain = false;
+        /// How many of the 256 MCNKs were read. A real 3.3.5a ADT has all of them, and
+        /// a cell no chunk reached keeps the zero the allocation gave it -- ground at
+        /// sea level, indistinguishable from real terrain once it is baked. The parser
+        /// reports; the baker refuses.
+        uint32_t chunksFilled = 0;
         std::vector<float> v9;
         std::vector<float> v8;
         std::array<uint16_t, ADT_CHUNKS * ADT_CHUNKS> holes{};

--- a/src/tools/extractor/client/MpqTileSource.cpp
+++ b/src/tools/extractor/client/MpqTileSource.cpp
@@ -31,27 +31,29 @@ namespace world::terrain
             return out;
         }
 
+        // Every placement goes through the THREE-ARGUMENT constructor, which is the only
+        // thing that screens the scale. MDDF stores it as a uint16 over 1024 and can say
+        // zero; assigning the field instead bakes that zero into the tile for good, and
+        // the runtime then divides by it in worldToLocal and misses every ray against
+        // the model -- silently, because a NaN compares false against everything.
+        //
         // Placement into the same world frame the terrain uses. The 180 degrees added to
         // the Z euler is the diag(-1,-1,1) axis flip, which is exactly a half-turn.
         Transform PlacementTransform(const Placement& p)
         {
-            Transform xf;
-            xf.pos = {MID - p.pos.z, MID - p.pos.x, p.pos.y};
-            xf.rot = Mat3::fromEuler(p.rotDeg.z * DEG2RAD, p.rotDeg.x * DEG2RAD,
-                                     (p.rotDeg.y + 180.0f) * DEG2RAD);
-            xf.scale = p.scale;
-            return xf;
+            return Transform({MID - p.pos.z, MID - p.pos.x, p.pos.y},
+                             Mat3::fromEuler(p.rotDeg.z * DEG2RAD, p.rotDeg.x * DEG2RAD,
+                                             (p.rotDeg.y + 180.0f) * DEG2RAD),
+                             p.scale);
         }
 
         // A WDT global WMO's MODF is already in world coordinates, so no re-centring.
         Transform GlobalWmoTransform(const Placement& p)
         {
-            Transform xf;
-            xf.pos = {p.pos.z, p.pos.x, p.pos.y};
-            xf.rot = Mat3::fromEuler(p.rotDeg.z * DEG2RAD, p.rotDeg.x * DEG2RAD,
-                                     (p.rotDeg.y + 180.0f) * DEG2RAD);
-            xf.scale = p.scale;
-            return xf;
+            return Transform({p.pos.z, p.pos.x, p.pos.y},
+                             Mat3::fromEuler(p.rotDeg.z * DEG2RAD, p.rotDeg.x * DEG2RAD,
+                                             (p.rotDeg.y + 180.0f) * DEG2RAD),
+                             p.scale);
         }
 
         // MODD's quaternion is authored against the M2's RAW model space, but M2Parser
@@ -66,11 +68,8 @@ namespace world::terrain
             r.m[4] = -r.m[4];
             r.m[7] = -r.m[7];
 
-            Transform xf;
-            xf.pos = wmoXf.localToWorld(d.pos);
-            xf.rot = Mat3::mulm(wmoXf.rot, r);
-            xf.scale = wmoXf.scale * d.scale;
-            return xf;
+            return Transform(wmoXf.localToWorld(d.pos), Mat3::mulm(wmoXf.rot, r),
+                             wmoXf.scale * d.scale);
         }
     }
 
@@ -178,6 +177,16 @@ namespace world::terrain
 
         AdtData adt;
         if (!ParseAdt(bytes, adt) || !adt.hasTerrain)
+        {
+            return nullptr;
+        }
+
+        // Every one of the 256 MCNKs, or no tile at all. A cell no chunk reached is not
+        // missing in the bake -- v9/v8 are allocated whole and zeroed, so it comes out
+        // as ground at sea level, which the server then serves as authoritative terrain
+        // under whatever mountain was supposed to be there. Refusing the tile leaves a
+        // hole the loader reports; accepting it leaves a lie nothing reports.
+        if (adt.chunksFilled != uint32_t(ADT_CHUNKS) * ADT_CHUNKS)
         {
             return nullptr;
         }

--- a/src/tools/extractor/client/StormLibArchive.cpp
+++ b/src/tools/extractor/client/StormLibArchive.cpp
@@ -119,9 +119,13 @@ namespace world::terrain
                 continue;
             }
 
+            // The high dword is not ignorable: resize() would take the low half and the
+            // caller would parse a silently TRUNCATED file as though it were whole.
+            // Nothing in a 3.3.5a client is 4 GiB, so this only fires when the tool is
+            // pointed at something that is not one.
             DWORD high = 0;
             const DWORD size = SFileGetFileSize(hFile, &high);
-            if (size == SFILE_INVALID_SIZE)
+            if (size == SFILE_INVALID_SIZE || high != 0)
             {
                 SFileCloseFile(hFile);
                 continue;

--- a/src/tools/extractor/client/WdtParser.cpp
+++ b/src/tools/extractor/client/WdtParser.cpp
@@ -20,6 +20,9 @@ namespace world::terrain
         const uint8_t* modf = nullptr;
         uint32_t modfSize = 0;
 
+        bool truncated = false;
+        bool haveMphd = false;
+
         size_t pos = 0;
         while (pos + 8 <= size)
         {
@@ -28,6 +31,7 @@ namespace world::terrain
             const uint8_t* body = data + pos + 8;
             if (pos + 8 + csize > size)
             {
+                truncated = true;
                 break;
             }
 
@@ -37,6 +41,7 @@ namespace world::terrain
                 {
                     out.mphdFlags = RdU32(body);
                     out.hasGlobalWmo = (out.mphdFlags & 0x0001) != 0;
+                    haveMphd = true;
                 }
             }
             else if (TagIs(tag, "MAIN"))
@@ -78,6 +83,20 @@ namespace world::terrain
         if (out.hasGlobalWmo && modf && modfSize >= 64)
         {
             out.globalWmoPlacement = ReadModf(modf);
+        }
+
+        // FAIL CLOSED. A WDT that lost its MAIN reads back as a map with no ADT grid at
+        // all, which the baker cannot tell from a map that legitimately has none: it
+        // writes nothing and reports success, and the map is simply absent from the bake
+        // with no error to find. Every 3.3.5a WDT carries MPHD and MAIN, and one that
+        // claims a global WMO carries the MODF that places it.
+        if (truncated || !haveMphd || !out.hasMainChunk)
+        {
+            return false;
+        }
+        if (out.hasGlobalWmo && (out.globalWmoName.empty() || !out.globalWmoPlacement))
+        {
+            return false;
         }
 
         return true;

--- a/src/tools/extractor/client/WmoParser.cpp
+++ b/src/tools/extractor/client/WmoParser.cpp
@@ -273,7 +273,13 @@ namespace world::terrain
             const uint64_t vbytes = uint64_t(xverts) * yverts * 8;
             const uint64_t fbytes = uint64_t(xtiles) * ytiles;
 
-            if (xverts && yverts && xtiles && ytiles && 30 + vbytes + fbytes <= mliqSize)
+            // The corner grid must be exactly one wider than the tile grid on each axis.
+            // Everything downstream -- the serializer's screen, WmoModel::LiquidLocal's
+            // four-corner interpolation -- assumes that relation and indexes on it, so a
+            // MLIQ that does not hold it is dropped here rather than baked into a tile
+            // that reads off the end of its own height vector.
+            if (xverts && yverts && xtiles && ytiles && xverts == xtiles + 1 &&
+                yverts == ytiles + 1 && 30 + vbytes + fbytes <= mliqSize)
             {
                 const uint8_t* verts = mliq + 30;
                 const uint8_t* tileFlags = verts + vbytes;

--- a/src/tools/extractor/nav/NavMeshBuilder.cpp
+++ b/src/tools/extractor/nav/NavMeshBuilder.cpp
@@ -885,14 +885,24 @@ namespace world::nav
             }
 
             // Every walkable poly must carry a flag or the query filter rejects all of
-            // them; the area id is what the server's filter then reads.
+            // them -- but the flag has to be the TERRAIN BIT, not a bare 1.
+            //
+            // Detour tests dtQueryFilter against polyFlags, never against the area id,
+            // and PathFinder builds its include mask out of the same NAV_* bits that are
+            // stored here as areas (NAV_GROUND 0x1, NAV_MAGMA 0x2, NAV_SLIME 0x4,
+            // NAV_WATER 0x8). Writing 1 for every non-empty poly told the filter that
+            // every polygon in the world is ground: a swimmer whose mask is
+            // WATER|MAGMA|SLIME then matches nothing at all and cannot path across its
+            // own lake, while a walker that includes GROUND is cleared to walk over
+            // magma. The area survives for whatever reads areas; the flag now says the
+            // same thing.
             for (int i = 0; i < merged->npolys; ++i)
             {
                 if (merged->areas[i] == RC_WALKABLE_AREA)
                 {
                     merged->areas[i] = NAV_GROUND;
                 }
-                merged->flags[i] = merged->areas[i] ? 1 : 0;
+                merged->flags[i] = merged->areas[i];
             }
 
             const std::vector<OffMeshLink> links =


### PR DESCRIPTION
# Geometry, terrain, collision disables, and a verified data set

Four topic branches, merged into `integration` as a single PR. Every defect below
was found either by diffing this tree's geometry/terrain/extractor against a revised
edition of the same code, or from the review findings on the mangos-four port of it
(`mangosfour/Server#78`).

They share a shape: **the bad answer is silence or a NaN**, and every comparison
against a NaN is false — so nothing reports an error. A ray misses, a creature is not
in the arc, a tile answers nothing, a map behaves oddly in one corner. From the
outside that is a server bug nobody can reproduce.

---

## Operator-facing — act on these

### New key in `mangosd.conf`

```ini
DataIntegrityCheck           = 1
```

| Value | Behaviour |
| --- | --- |
| `0` | off |
| `1` | **default** — re-hash the data set at start-up, report a mismatch, start anyway |
| `2` | refuse to start on a mismatch |

The full documentation block sits above `RealmID` in `mangosd.conf.dist.in`. It costs a
few seconds once, spread across every core. A data set with **no** manifest is reported
and accepted, never refused. Checkable by hand with a tool that was not written here:

```sh
cd <DataDir> && sha256sum -c data.manifest
```

### A re-bake is required

Tile format `1 → 2`, `MMAP_VERSION 6 → 7`. Neither layout changed — what changed is
**which files are accepted** and **what a navmesh polygon flag means**. An old tile is
now rejected, and a rejected tile is silence: no height, no liquid, no collision, no
diagnostic beyond the miss. An old navmesh paths wrongly. Re-run `mangos-extractor`;
the same run writes the new `data.manifest`.

### The extractor's exit code now means something

Tile bake failures used to be logged and then discarded — `main` returned 0.
`linux/getmangos.sh` deletes the installed data *before* running it and reads 0 as
"the extraction is complete", so a partial bake left a world with holes and said
nothing. The nav pass enumerates the tiles that **were** written, so it cannot notice
either. Any install script that ignores the status should be revisited.

### The `disables` table starts working

`DISABLE_TYPE_VMAP` rows were loaded, validated against `Map.dbc`, logged per flag and
reloadable — and read by nobody. If your database has rows there, all four flags
(`AREAFLAG` / `HEIGHT` / `LOS` / `LIQUIDSTATUS`) take effect for the first time.
`.reload disables` now pushes changes into maps already in memory.

---

## `geometry-fixes` — `src/shared/Geometry/`

- **`HasInArc` normalised the arc WIDTH.** `NormalizeOrientation` wraps into the
  half-open `[0, 2π)`, so a full circle came back as zero, halved to zero, and matched
  only a target dead ahead. Reachable today: `IsInBack(other, dist, arc)` asks for
  `HasInArc(2π - arc)`, so an arc of zero meant "everything is behind me" — including a
  creature standing in plain sight.
- `Vector3::direction()` and `Quat::unitize()` divided by the length of a zero-length
  value. `1/sqrt(0)` is infinity and the result is all NaN.
- `wrap()` converted the quotient through `int`. **Reachable from a client packet** —
  `MoveSpline` normalises the orientation the client reports — so a NaN or a value more
  than 2³¹ intervals from `lo` was undefined behaviour, not a wrong angle.
- The bare-point overloads (`DistanceTo`, `WithinDist`, `WithinRange`, `WithinBox`)
  answered for an **unplaced** placement as though it stood at the origin of a map it is
  not on — an item in a bag measuring 8843 yards from Stormwind rather than nowhere.
- `Closer` and `InBand` compared strictly, so `WithinDist(x, DistanceTo(x))` was false
  by construction: `DistanceTo` returns the separation minus the extents, and feeding it
  back asked whether a number is less than itself.
- `Aabb::expand(const Aabb&)` folded an **empty** box (`lo = +max, hi = -max`) into the
  accumulator and widened it to the whole float range, whose extent overflows to
  infinity — after which every SAH split of the BVH costs the same. `valid()` checked x
  alone; the slab test dropped an axis whose reciprocal was not finite.

**Deliberately not changed:** `twoPi()`/`halfPi()` keep their g3dlite literals — the
header states the values are reproduced verbatim so the math stays numerically identical
to the former dependency, and `2*pi()` rounds to the same float anyway.

## `terrain-fixes` — terrain engine + baker

### Reading a tile

- **`Bvh::Adopt` took a node array off disk and moved it in.** Nothing downstream
  re-checks: `Raycast` pushes both children unconditionally onto a stack sized from
  `MAX_DEPTH`, indexes the array with whatever it popped, and reads a leaf's triangle run
  without a bounds test. All three are safe only because `Build` cannot emit an array
  that violates them — a file can, and the format has no checksum. `Adopt` now verifies
  the array is a depth-first tree over the triangles it indexes; `TriSoup::IndicesValid`
  screens the triangles once, because `At()` cannot afford a check per ray.
- `BuildNode` cut off at `depth > MAX_DEPTH`, so the deepest node it made was
  `MAX_DEPTH + 1` — against a comment on that constant saying otherwise.
- `ReadTile` accepted grids of any size while `TerrainHeight` and `LiquidAt` index them
  by fixed arithmetic; a WMO group count bounded by `MAX_MODELS` (2²⁰) where reality is a
  few hundred; a liquid grid whose counts disagree with its own vectors; and an instance
  scale read straight into the field, bypassing the clamping constructor whose comment
  says a non-positive or non-finite scale is screened once.
- `WriteTile` ignored `fclose`, which is what flushes: a full disk left a truncated tile
  that looks complete.
- `FusedTerrain::HasTile` answered the start-up question by opening the file. It reads
  the tile now — once per checked grid, never on a query path.

### Querying

- **`CollectSegmentInstances` sampled the sight line every half tile.** A sample step
  only guarantees the tiles it lands in, so a segment clipping the **corner** of a tile
  was missed entirely and the wall standing in it occluded nothing — from those angles
  only. Replaced by a supercover tile walk, which advances to the next boundary.
- `TileIndex` truncated toward zero in front of the shift, so the strip past the far
  corner of the map answered with the tile at the opposite edge.
- `WmoModel::LiquidLocal` converted to `int` before range-testing (undefined for a point
  far outside the group, which is most of the model most of the time) and interpolated
  four corners of a height grid whose shape it never checked.
- `GoModelStore::Get` held its mutex across the disk read, serialising every game-object
  spawn in the world behind one open.
- `PinCell` incremented an `int16` without a ceiling; `TerrainInfo::Load` pinned per
  reference while `Unload` released only on the last, so N owners of one grid left it
  pinned N-1 times and the sweep never evicted it.

### Baking

- Bake failures now reach the exit code, and a map that declares a global WMO and cannot
  bake it counts as a failure rather than being confused with a map that declares none.
- A short MCNK header was read anyway (the fields reach `0x74`); a chunk with no usable
  MCVT still counted as read, and the zero-filled grid it left behind bakes as flat ground
  at sea level. Neither contributes to the chunk count now, and a tile missing any of its
  256 chunks is not written.
- A truncated ADT or a WDT without MPHD/MAIN fails the parse outright. An MLIQ whose
  corner grid is not one wider than its tile grid is dropped. An MPQ file whose size needs
  the high dword is refused rather than read truncated. Placements go through the clamping
  `Transform` constructor.
- **`NavMeshBuilder` wrote `flags[i] = areas[i] ? 1 : 0`.** Detour filters on flags, never
  on the area id, and `PathFinder`'s masks are the `NAV_*` bits — so every polygon in the
  world claimed to be ground: a swimmer's `WATER|MAGMA|SLIME` mask matched nothing and a
  walker was cleared across magma.

## `collision-disables`

The four collision flags now reach the query paths, resolved **once per map id** in
`TerrainInfo` and re-pushed by `TerrainManager::RefreshCollisionDisables` on reload —
asking the table inside every height and sight query would put a container lookup on the
hottest path in the server.

The lookup itself is new: `IsDisabledFor` reaches its container through `operator[]`,
which **inserts** when a type has no rows, so calling it from map threads would be a write
racing a reload's clear. `GetCollisionDisablesFor` only reads.

Meanings are unchanged from when this was a vmap: `HEIGHT` drops baked model floors and
leaves the ADT heightmap; `LIQUIDSTATUS` drops WMO liquid and leaves the ADT's own; `LOS`
stops baked geometry blocking and **not** the dynamic tree (a map with sight disabled still
has doors) — covered on both halves, `IsInLineOfSight` **and** `NearestHitFraction`, or a
disabled map would report clear sight and still stop a spell at the wall it had just said
was not there; `AREAFLAG` makes `GetAreaInfo` report no WMO.

The terrain engine takes a mask of which **surface kinds** to gather and is told nothing
about why one is excluded. It never learns that a database table exists.

## `data-integrity`

A tile carries a format version, so a bake from an older extractor is refused on sight.
That is the only thing a version can catch. Everything else produces files that are
structurally perfect: a tile truncated by a full disk or an interrupted copy, a map whose
tiles came half from one bake and half from another, a stale file an older run left behind,
a sector that rotted years after the bake.

The baker records a SHA-256 per file; the server re-hashes at start-up, right after the
start-area tile check and before the DBCs load.

- **Format:** `<64 hex>  <path>` per line, sorted, LF, at `<DataDir>/data.manifest` —
  deliberately the layout `sha256sum -c` reads. No header and no comment, because either
  would break that.
- **Where the code lives:** `dataintegrity`, a library of its own carrying OpenSSL and
  nothing else. Not part of `shared`, which exports MySQL publicly — linking that into the
  baker to reach two files would drag a database client into a tool that has never needed
  one. One implementation, two consumers, so the format cannot drift from itself.
- **What it is not:** authentication. The manifest sits beside the files it describes.
- A file present on disk that the manifest does not list is **not** an error.

---

## Verification

| Check | Result |
| --- | --- |
| MSVC x64 Release, full build | `EXIT=0`, zero errors, all 12 binaries produced |
| `mangos_tests` | **205 tests, 0 failed** |
| GCC / Clang | not run — CI |
| New tests seen red against the unfixed code | **not done** |

New coverage: BVH adopt rejections, triangle index screening, the `TileIndex` floor, the
ADT chunk count and the truncated-chunk contract, the full-circle arc, the unplaced item,
the closed reach limit, source-mask exclusion, and the SHA-256 vectors — checked against
the **published** FIPS 180-4 values, including the million-`a` case, because a hash
agreeing with itself proves nothing and this one has to agree with `sha256sum`.

`AdtStopsOnTruncatedChunk` changes meaning: it asserted that a chunk claiming
`0x7FFFFFFF` bytes parses as an empty tile, which the function's own contract calls a
structurally broken file.

## Known, present, not fixed

Two findings from the four port are real here and left alone, both needing a real client
to verify against:

- WMO liquid answers from the first group in serialised order rather than the one
  containing the query point (stacked pools). Fixing it is a redesign of the column API.
- The WMO area probe accepts an instance up to 300 yards below the query point.

Also real and homeless: `ParseIdList` rejects map id `0`, so
`LoadAllGridsOnMaps = 0` (Eastern Kingdoms) silently does nothing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/259)
<!-- Reviewable:end -->
