### PR TITLE
[Movement] Effect splines: push the generator before launch, resume the one beneath on expiry

### DIFF
--- a/src/game/MotionGenerators/MotionMaster.cpp
+++ b/src/game/MotionGenerators/MotionMaster.cpp
@@ -730,12 +730,15 @@ bool MotionMaster::GetDestination(float& x, float& y, float& z)
 
 void MotionMaster::MoveJump(float x, float y, float z, float horizontalSpeed, float max_height, uint32 id)
 {
+    // Push first: Mutate interrupts the generator on top, and that interrupt
+    // finalizes the live spline - launching earlier let it kill the jump itself.
+    Mutate(new EffectMovementGenerator(id));
+
     Movement::MoveSplineInit init(*m_owner);
     init.MoveTo(x, y, z);
     init.SetParabolic(max_height, 0);
     init.SetVelocity(horizontalSpeed);
     init.Launch();
-    Mutate(new EffectMovementGenerator(id));
 }
 
 void MotionMaster::MoveJump(Position& pos, float horizontalSpeed, float max_height, uint32 id)
@@ -765,9 +768,11 @@ void MotionMaster::MoveFall()
         return;
     }
 
+    // Push first, same reason as MoveJump.
+    Mutate(new EffectMovementGenerator(0));
+
     Movement::MoveSplineInit init(*m_owner);
     init.MoveTo(m_owner->Where().X(), m_owner->Where().Y(), tz);
     init.SetFall();
     init.Launch();
-    Mutate(new EffectMovementGenerator(0));
 }

--- a/src/game/MotionGenerators/PointMovementGenerator.cpp
+++ b/src/game/MotionGenerators/PointMovementGenerator.cpp
@@ -171,19 +171,15 @@ void EffectMovementGenerator::Finalize(Unit& owner)
         creature.AI()->MovementInform(EFFECT_MOTION_TYPE, m_id);
     }
 
-    // Restore the previous movement, since we have no proper state system for it.
     if (!owner.IsAlive() ||
         owner.hasUnitState(UNIT_STAT_CONFUSED | UNIT_STAT_FLEEING | UNIT_STAT_NO_COMBAT_MOVEMENT))
     {
         return;
     }
 
+    // Expiring drops the chase beneath us, so re-lay it; anything else beneath resumes by itself.
     if (Unit* victim = owner.getVictim())
     {
         owner.GetMotionMaster()->MoveChase(victim);
-    }
-    else
-    {
-        owner.GetMotionMaster()->Initialize();
     }
 }


### PR DESCRIPTION
`MotionMaster::MoveJump`/`MoveFall` launched the jump spline and only then pushed the `EffectMovementGenerator`. `Mutate` interrupts the generator on top, and every intent generator interrupts by finalizing the live spline, so the jump was dead server-side before its first tick while the client still played it. The effect then expired immediately, fired `MovementInform(EFFECT)` at the launch point, and `EffectMovementGenerator::Finalize` re-laid the chase from there (or reset the whole stack to the DB default when there was no victim) - the knockback rubber-band, and scripted `MovePoint`/path legs lost after any jump or fall.

- Push the effect generator first, then launch (Effect's `Initialize`/`Interrupt` are no-ops, so the order is free).
- `Finalize` no longer calls `MotionMaster::Initialize()`; popping already resumes whatever is beneath. The `MoveChase(victim)` re-lay stays because `DirectExpire` drops the chase under an expiring effect.

Same code as mangosthree (paired with mangosthree/server#341). Verified there headless with an Eluna scenario (MoveJump over a MovePoint leg, over a chase with a victim, MoveFall): before - position frozen at the launch point, effect inform at +<400 ms, stack reset to RANDOM; after - the arc completes server-side and the leg/chase resumes from the landing point.

Affects creature knockback (`KnockBackWithAngle`), `EffectPlayerPull`, jump-dest effects and any script `MoveJump` on a moving actor.


The red "Windows Build (MSVC)" check is the slproweb OpenSSL 3.6.3 installer 404, not this change - fixed by #262.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/261)
<!-- Reviewable:end -->
