### PR TITLE
[Pathfinding] Report a full smooth-path buffer as truncated, not failed

### DIFF
--- a/src/game/MotionGenerators/PathFinder.cpp
+++ b/src/game/MotionGenerators/PathFinder.cpp
@@ -966,8 +966,9 @@ dtStatus PathFinder::findSmoothPath(const float* startPos, const float* endPos,
 
     *smoothPathSize = nsmoothPath;
 
-    // Return success if the smooth path size is within the maximum limit.
-    return nsmoothPath < MAX_POINT_PATH_LENGTH ? DT_SUCCESS : DT_FAILURE;
+    // A full buffer is a truncated route, not a failed one: the caller marks it
+    // INCOMPLETE and the mover re-paths from the far end of the corridor.
+    return (npolys && nsmoothPath >= maxSmoothPathSize) ? (DT_SUCCESS | DT_BUFFER_TOO_SMALL) : DT_SUCCESS;
 }
 
 /**


### PR DESCRIPTION
`PathFinder::findSmoothPath` walks the poly corridor in 4-yd steps and stops when its point buffer (`MAX_POINT_PATH_LENGTH` = 74) is full, then returns `DT_FAILURE` for exactly that case. `BuildPointPath` treats a failed status as `PATHFIND_NOPATH` and replaces the corridor with a straight-line shortcut, so every route longer than ~296 yd of smoothed points is reported as unreachable. A follower that far behind never moves (`MOVE_REQUIRE_PATH` + `Failed()` → blocked); the force-destination branch for pets sits after that early return and never runs.

A smaller per-intent limit (`setPathLengthLimit` → fewer points) already returns the truncated path and `BuildPointPath` marks it `PATHFIND_INCOMPLETE` because the actual end is short of the target; the 74-point case is the only one that fails instead. Return success with `DT_BUFFER_TOO_SMALL` at the cap and let the existing truncation check do its job - `PartialPathProgresses` then accepts the corridor and the mover re-paths from its far end.

Verified headless on the live 4.3.4 build: a `MoveFollow` across 372 yd of open Mulgore stood still for 150 s while a 192-yd control arrived; with this change it walks the corridor and keeps re-pathing (250 yd covered in the same 150 s window, still closing). Paired with mangosthree/server#344.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/263)
<!-- Reviewable:end -->
