### PR TITLE
[Movement] Gate StopMoving on the spline, not on the *_MOVE states

### DIFF
--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -5627,15 +5627,17 @@ void Unit::SendPetAIReaction()
 
 void Unit::StopMoving(bool forceSendStop /*=false*/)
 {
-    if (IsStopped() && !forceSendStop)
-    {
-        return;
-    }
-
     clearUnitState(UNIT_STAT_MOVING);
 
     // not need send any packets if not in world
     if (!IsInWorld())
+    {
+        return;
+    }
+
+    // Gate on the spline, not on the *_MOVE states: home legs, effects and raw
+    // script splines set none, and skipping them left the spline running.
+    if (movespline->Finalized() && !forceSendStop)
     {
         return;
     }


### PR DESCRIPTION
`Unit::StopMoving` bails out on `IsStopped()`, i.e. when no `UNIT_STAT_*_MOVE` state is set. `HomeMovementGenerator`, `EffectMovementGenerator` and raw script splines never set one, so for them `StopMoving` was a no-op and the spline kept running under whatever came next: `SetDeathState` could not stop a creature killed mid-evade (the corpse slid on toward home), `MotionMaster::Initialize` could not stop a stale leg on respawn (the walk-in-place ghost), `ConfusedMovementGenerator::Interrupt` left the wander running.

Gate on `movespline->Finalized()` instead - the spline is the thing being stopped, and `MoveSplineInit::Stop` is already a no-op on a finalized one, so callers that stop every tick while rooted or casting cost nothing extra. TC 4.3.4's `StopMoving` has no state gate at all. All call sites (29 core, 29 SD3) intend a real stop.

Verified headless on the live 4.3.4 build: a creature killed 32 yd into a `MoveHome` leg kept moving 15-18 yd after `dead=true`; with this change it stays where it died. Paired with mangosthree/server#345.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/264)
<!-- Reviewable:end -->
