### PR TITLE
[Movement] Inform POINT arrival only for a leg that actually arrived

### DIFF
--- a/src/game/MotionGenerators/PointMovementGenerator.cpp
+++ b/src/game/MotionGenerators/PointMovementGenerator.cpp
@@ -62,9 +62,9 @@ void PointMovementGenerator::Finalize(Unit& owner)
 {
     owner.clearUnitState(UNIT_STAT_ROAMING | UNIT_STAT_ROAMING_MOVE);
 
-    // Only a leg that ran to completion counts as reaching the point; one cut short by an
-    // interrupt does not.
-    if (owner.movespline->Finalized())
+    // Only a leg that ended on its own counts as reaching the point. One cut short by an
+    // interrupt finalizes the spline too, so the spline state cannot tell them apart.
+    if (m_done)
     {
         MovementInform(owner);
     }
@@ -118,6 +118,7 @@ Motion::MoveIntent PointMovementGenerator::Intent(Unit& owner,
     // and the generator beneath it takes back over. Finalize fires the AI inform.
     if (status.arrived || status.blocked)
     {
+        m_done = true;
         return Motion::MoveIntent::Done();
     }
 

--- a/src/game/MotionGenerators/PointMovementGenerator.h
+++ b/src/game/MotionGenerators/PointMovementGenerator.h
@@ -39,7 +39,7 @@ class PointMovementGenerator : public IntentMovementGenerator
 {
     public:
         PointMovementGenerator(uint32 id, float x, float y, float z, bool generatePath)
-            : m_id(id), m_dest(x, y, z), m_generatePath(generatePath) {}
+            : m_id(id), m_dest(x, y, z), m_generatePath(generatePath), m_done(false) {}
 
         void Initialize(Unit& owner) override;
         void Finalize(Unit& owner) override;
@@ -64,6 +64,7 @@ class PointMovementGenerator : public IntentMovementGenerator
         uint32 m_id;             ///< Echoed to the AI on arrival.
         Motion::Vector3 m_dest;  ///< Where we are going.
         bool m_generatePath;     ///< Route around geometry, or go straight there.
+        bool m_done;             ///< The leg ended on its own: arrived, or could not be laid.
 };
 
 /**


### PR DESCRIPTION
`PointMovementGenerator::Finalize` reports arrival whenever `owner.movespline->Finalized()` - but `Interrupt()` → `InterruptMoving()` finalizes the spline as well, so a `MovePoint` leg interrupted by a chase and later popped (`Clear`, `DirectExpire`'s targeted drop, despawn) fires `MovementInform(POINT_MOTION_TYPE, id)` from wherever the creature happens to stand. Script step machines advance on that spurious inform.

`PathMovementGenerator` already does this right with an `m_arrived` flag set from the driver's arrival edge; give `PointMovementGenerator` the same flag and inform on it.

Verified headless on the live 4.3.4 build: a wolf 30 yd short of its `MovePoint` target, pulled off it by a chase that arrived and stopped, then `MoveClear`ed, fired the POINT inform 45 yd from the point; with this change it does not, while a leg that runs to its point still informs. Paired with mangosthree/server#346.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/265)
<!-- Reviewable:end -->
