### PR TITLE
[Movement] Flee back toward the fear source, not along its mirror image

### DIFF
--- a/src/game/MotionGenerators/FleeingMovementGenerator.cpp
+++ b/src/game/MotionGenerators/FleeingMovementGenerator.cpp
@@ -77,9 +77,10 @@ std::optional<Motion::Vector3> FleeingMovementGenerator::PickFleePoint(Unit& own
     }
     else if (distFromCaster > MAX_QUIET_DISTANCE)
     {
-        // Further than the panic band: drift back toward it.
+        // Further than the panic band: drift back toward it. Negating the bearing
+        // mirrored it across the x axis instead; toward the caster is bearing + pi.
         dist = frand(0.4f, 1.0f) * (MAX_QUIET_DISTANCE - MIN_QUIET_DISTANCE);
-        angle = -angleToCaster + frand(-M_PI_F / 4, M_PI_F / 4);
+        angle = angleToCaster + M_PI_F + frand(-M_PI_F / 4, M_PI_F / 4);
     }
     else
     {


### PR DESCRIPTION
`FleeingMovementGenerator::PickFleePoint` takes `angleToCaster` = the caster→mover bearing. Inside 28 yd it bolts along that bearing (away), past 43 yd it is meant to drift back toward the caster - but it uses `-angleToCaster`, which mirrors the bearing across the x axis instead of reversing it. That only faces the caster when the two stand on a north/south line; on an east/west line (bearing π → -π) the mover keeps running away, and on a diagonal it goes sideways. Toward the caster is `angleToCaster + π`. Inherited from cmangos/TC, which have the same expression.

Verified headless on the live 4.3.4 build: a wolf feared by a source 60 yd due east kept fleeing away (61 → 81 yd in 6 s); with this change it drifts back into the band (60 → 41 yd) and mills there. Paired with mangosthree/server#347.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/266)
<!-- Reviewable:end -->
