### PR TITLE
[Movement] Waypoint tick: skip stale intents, break the dead-node loop

### DIFF
--- a/src/game/MotionGenerators/IntentMovementGenerator.h
+++ b/src/game/MotionGenerators/IntentMovementGenerator.h
@@ -54,7 +54,16 @@ class IntentMovementGenerator : public MovementGenerator
         bool Update(Unit& owner, const uint32& diff) final
         {
             const Motion::MoveStatus status = m_driver.BeginTick(owner);
-            return m_driver.Apply(owner, Intent(owner, status, diff));
+            const Motion::MoveIntent intent = Intent(owner, status, diff);
+
+            // A hook fired from inside Intent (a waypoint inform, a script) may have pushed
+            // or popped generators: a leg laid now would belong to one no longer on top.
+            if (!IsActive(owner))
+            {
+                return true;
+            }
+
+            return m_driver.Apply(owner, intent);
         }
 
         void unitSpeedChanged() final { m_driver.OnSpeedChanged(); }

--- a/src/game/MotionGenerators/WaypointMovementGenerator.cpp
+++ b/src/game/MotionGenerators/WaypointMovementGenerator.cpp
@@ -236,6 +236,7 @@ void WaypointMovementGenerator::OnArrived(Creature& creature)
     }
 
     m_lastReachedWaypoint = m_currentNode;
+    m_deadNodes = 0;
 
     if (m_isArrivalDone)
     {
@@ -436,7 +437,7 @@ Motion::MoveIntent WaypointMovementGenerator::WalkPreparedLeg() const
 {
     // The pace rides on the intent: the driver resolves walk/run from MOVE_WALK alone, so
     // the unit-level SetWalk in PrepareMove is not enough to make a patrol walk.
-    uint32 flags = Motion::MOVE_REQUIRE_PATH;
+    uint32 flags = m_forceNextLeg ? Motion::MOVE_NONE : Motion::MOVE_REQUIRE_PATH;
     if (m_legWalk)
     {
         flags |= Motion::MOVE_WALK;
@@ -568,7 +569,18 @@ Motion::MoveIntent WaypointMovementGenerator::Intent(Unit& owner,
         ClearSegment();
         m_isArrivalDone = true;
         m_haveLeg = false;
+        m_forceNextLeg = false;
         Stop(SKIP_DEAD_NODE_DELAY);
+
+        // A whole lap of unreachable nodes means WE are off the mesh, not the nodes: walk
+        // the next leg unrouted so the straight line puts the creature back on it.
+        if (++m_deadNodes >= m_path->size())
+        {
+            m_deadNodes = 0;
+            m_forceNextLeg = true;
+            DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "%s skipped every waypoint as unreachable, walking the next leg unrouted",
+                             creature.GetGuidStr().c_str());
+        }
     }
 
     if (Stopped(creature))

--- a/src/game/MotionGenerators/WaypointMovementGenerator.cpp
+++ b/src/game/MotionGenerators/WaypointMovementGenerator.cpp
@@ -491,14 +491,23 @@ Motion::MoveIntent WaypointMovementGenerator::PrepareMove(Creature& creature)
 
         if (creature.AI() && m_pathOrigin == PATH_FROM_EXTERNAL && m_pathId > 0)
         {
+            const uint32 nodeBefore = m_currentNode;
             creature.AI()->MovementInform(
                 (reachedLast ? EXTERNAL_WAYPOINT_FINISHED_LAST : EXTERNAL_WAYPOINT_MOVE_START) + m_pathId,
                 currPoint->first);
 
-            // That hook may have despawned the creature or swapped its path.
-            if (creature.IsDead() || !creature.IsInWorld())
+            // That hook may have despawned the creature, swapped its path, or put another
+            // generator on top of this one.
+            if (creature.IsDead() || !creature.IsInWorld() || !IsActive(creature))
             {
                 return Motion::MoveIntent::Hold();
+            }
+
+            // A SetNextWaypoint from inside the hook re-targets the step; keep it.
+            if (m_currentNode != nodeBefore)
+            {
+                currPoint = m_path->find(m_currentNode);
+                MANGOS_ASSERT(currPoint != m_path->end());
             }
         }
 

--- a/src/game/MotionGenerators/WaypointMovementGenerator.h
+++ b/src/game/MotionGenerators/WaypointMovementGenerator.h
@@ -197,6 +197,8 @@ class WaypointMovementGenerator final : public IntentMovementGenerator
         Motion::Facing m_legFacing;
         bool m_legWalk = true; ///< Pace of the leg; false only for a DB-flagged runner.
         bool m_haveLeg = false;
+        uint32 m_deadNodes = 0;      ///< Nodes skipped as unreachable in a row.
+        bool m_forceNextLeg = false; ///< Walk the next leg unrouted: a whole lap was unreachable.
 };
 
 /**


### PR DESCRIPTION
Two waypoint-tick faults, one per commit.

**Stale intent after a hook.** `IntentMovementGenerator::Update` applies whatever `Intent()` returns, but a waypoint tick fires `MovementInform`/scripts from inside `Intent` (`OnArrived`, the external move-start inform in `PrepareMove`). A hook that calls `MovePoint`/`MoveChase`/`Clear` pushes or pops generators; control returns into `PrepareMove`, which lays a leg, and `Apply` launches it for a generator no longer on top - a wasted `MONSTER_MOVE` and a stutter until the new top lays its own leg. Eluna's creature AI works around exactly this by queueing informs until `UpdateAI` ("starting new movement would bug"); SD3 informs are synchronous and get no such protection. The pre-intent code guarded this with `MovementGenerator::IsActive`, which had no callers left. Check it between `Intent` and `Apply`, bail out of `PrepareMove` after its inform the same way, and keep a `SetNextWaypoint` issued from that inform instead of clobbering it. The guard only changes behaviour when `top() != this` after `Intent`, i.e. when a hook did mutate the stack; the harness patrol scenarios are unaffected.

**Dead-node loop.** A blocked leg counts as arrived so a patrol steps over an unreachable node after 50 ms - but a creature that is itself off the mesh gets NOPATH for every node and cycles its whole path forever, firing move-start informs and `model2` swaps every lap. Count consecutive skips; after a full lap lay the next leg without `MOVE_REQUIRE_PATH` so the straight shortcut walks the creature back onto the mesh, then route normally.

Verified headless on the live 4.3.4 build (Kalimdor fully loaded, instrumented builds): on the unfixed build a patroller lifted 60 yd above its route skipped nodes non-stop, and the same trace showed **59 distinct DB creatures** already cycling their paths this way in the shipped world; on the fixed build each of them logs one completed lap and lays a forced leg (17 laps, skip count halved in the same window), and the lifted patroller walks the 60 yd back down to its route and resumes patrolling; a fresh patroller on a 4-node square walks it in order. Paired with mangosthree/server#348.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/267)
<!-- Reviewable:end -->
