### PR TITLE
[Movement] Tell a cut or partial leg from an arrival

### DIFF
--- a/src/game/MotionGenerators/HomeMovementGenerator.cpp
+++ b/src/game/MotionGenerators/HomeMovementGenerator.cpp
@@ -73,6 +73,8 @@ Motion::MoveIntent HomeMovementGenerator::Intent(Unit& /*owner*/,
         return Motion::MoveIntent::Done();
     }
 
+    // A stop on the way (a stun, a root) is not an arrival: the leg is re-stated once the
+    // unit may move again, and JustReachedHome fires at home, not where the stun landed.
     return Motion::MoveIntent::Move(m_home, Motion::MOVE_NONE,
                                     Motion::Facing::ToAngle(m_facing));
 }

--- a/src/game/MotionGenerators/MotionDriver.cpp
+++ b/src/game/MotionGenerators/MotionDriver.cpp
@@ -47,6 +47,7 @@ void MotionDriver::ResetLeg()
 {
     m_legGoal = Motion::Vector3();
     m_haveLeg = false;
+    m_partialLeg = false;
     m_blocked = false;
     m_speedChanged = false;
     m_wasTraveling = false;
@@ -78,8 +79,26 @@ Motion::MoveStatus MotionDriver::BeginTick(Unit& owner)
 
     Motion::MoveStatus status;
     status.traveling = traveling;
-    status.arrived = m_wasTraveling && !traveling;
     status.blocked = m_blocked;
+
+    // A leg that just ended did so in one of three ways, and they must not be confused:
+    // it ran out at its goal (arrived), something stopped or interrupted it (cut), or it
+    // ran out at the far end of a route that only got partway (partial).
+    if (m_wasTraveling && !traveling)
+    {
+        if (owner.movespline->Cut())
+        {
+            status.cut = true;
+        }
+        else if (m_partialLeg)
+        {
+            status.partial = true;
+        }
+        else
+        {
+            status.arrived = true;
+        }
+    }
     status.pathIndex = owner.movespline->Initialized() ? owner.movespline->currentPathIdx() : 0;
 
     if (m_haveLeg)
@@ -142,6 +161,7 @@ bool MotionDriver::ReconcileMove(Unit& owner, Motion::MoveIntent const& intent)
 bool MotionDriver::LayLeg(Unit& owner, Motion::MoveIntent const& intent)
 {
     Movement::MoveSplineInit init(owner);
+    m_partialLeg = false;
 
     if (intent.path && intent.path->size() >= 2)
     {
@@ -167,13 +187,17 @@ bool MotionDriver::LayLeg(Unit& owner, Motion::MoveIntent const& intent)
         // Nothing usable at all, or the router failed and this movement kind refuses the
         // straight-line fallback. Either way no leg is laid, and the generator is told
         // so next tick so it can give up or pick somewhere else.
-        if (!routed || (intent.Has(Motion::MOVE_REQUIRE_PATH) && query->Failed()))
+        // Likewise a partial route that gets no closer to the goal: laying it would walk
+        // nowhere and re-lay itself from the same spot every tick.
+        if (!routed || (intent.Has(Motion::MOVE_REQUIRE_PATH) && query->Failed()) ||
+            (query->Partial() && !query->Progresses()))
         {
             m_blocked = true;
             return false;
         }
 
         init.MovebyPath(query->Points());
+        m_partialLeg = query->Partial();
     }
 
     switch (intent.facing.mode)
@@ -207,13 +231,19 @@ bool MotionDriver::LayLeg(Unit& owner, Motion::MoveIntent const& intent)
     // The velocity is left to MoveSplineInit, which resolves the unit's live
     // walk/run/swim/flight speed at Launch -- so a speed change re-paces the next leg
     // instead of a stale value being baked in here.
-    init.Launch();
+    if (init.Launch() == 0)
+    {
+        // The spline refused the leg (Validate): nothing is running, and the next tick
+        // must not judge whatever spline was there before.
+        m_blocked = true;
+        return false;
+    }
 
     m_legGoal = intent.goal;
     m_haveLeg = true;
     m_blocked = false;
     m_speedChanged = false;
-    m_wasTraveling = true;
+    m_wasTraveling = !owner.movespline->Finalized();
 
     return true;
 }

--- a/src/game/MotionGenerators/MotionDriver.h
+++ b/src/game/MotionGenerators/MotionDriver.h
@@ -94,6 +94,7 @@ class MotionDriver
         /// destination has moved far enough to be worth re-routing.
         Motion::Vector3 m_legGoal;
         bool m_haveLeg = false;
+        bool m_partialLeg = false;   ///< The running leg's route only got partway to its goal.
 
         bool m_blocked = false;      ///< The last Move could not be laid.
         bool m_speedChanged = false; ///< A speed change invalidated the running leg.

--- a/src/game/MotionGenerators/MotionFrame.cpp
+++ b/src/game/MotionGenerators/MotionFrame.cpp
@@ -85,6 +85,19 @@ namespace Motion
                             (PATHFIND_NOPATH | PATHFIND_NOT_USING_PATH)) == 0;
                 }
 
+                bool Partial() const override
+                {
+                    return (m_path.getPathType() & PATHFIND_INCOMPLETE) != 0;
+                }
+
+                bool Progresses() const override
+                {
+                    // Under a yard of travel is a route that ends where it starts.
+                    const float advance =
+                        (m_path.getActualEndPosition() - m_path.getStartPosition()).magnitude();
+                    return advance >= 1.0f;
+                }
+
                 bool Reachable() const override
                 {
                     return (m_path.getPathType() & PATHFIND_NORMAL) != 0;
@@ -290,6 +303,19 @@ namespace Motion
                 {
                     return (m_path.getPathType() &
                             (PATHFIND_NOPATH | PATHFIND_NOT_USING_PATH)) == 0;
+                }
+
+                bool Partial() const override
+                {
+                    return (m_path.getPathType() & PATHFIND_INCOMPLETE) != 0;
+                }
+
+                bool Progresses() const override
+                {
+                    // Under a yard of travel is a route that ends where it starts.
+                    const float advance =
+                        (m_path.getActualEndPosition() - m_path.getStartPosition()).magnitude();
+                    return advance >= 1.0f;
                 }
 
                 bool Reachable() const override

--- a/src/game/MotionGenerators/MotionFrame.h
+++ b/src/game/MotionGenerators/MotionFrame.h
@@ -122,6 +122,13 @@ namespace Motion
              */
             virtual bool Routed() const = 0;
 
+            /// The last route only got partway: its far end is a waypoint, not the goal.
+            virtual bool Partial() const = 0;
+
+            /// A partial route worth walking: it moves the mover. One that ends where
+            /// it starts would be laid again from the same spot every tick.
+            virtual bool Progresses() const = 0;
+
             /// False when the last route only got partway to the goal.
             virtual bool Reachable() const = 0;
     };

--- a/src/game/MotionGenerators/MotionMaster.cpp
+++ b/src/game/MotionGenerators/MotionMaster.cpp
@@ -231,13 +231,17 @@ void MotionMaster::DirectExpire(bool reset)
     MovementGenerator* curr = top();
     pop();
 
-    // Also drop stored under top() targeted motions
-    while (!empty() && (top()->GetMovementGeneratorType() == CHASE_MOTION_TYPE || top()->GetMovementGeneratorType() == FOLLOW_MOTION_TYPE))
+    // Also drop stored under top() targeted motions -- except beneath a transient effect
+    // (a jump, a knockback), which resumes whatever it interrupted.
+    if (curr->GetMovementGeneratorType() != EFFECT_MOTION_TYPE)
     {
-        MovementGenerator* temp = top();
-        pop();
-        temp->Finalize(*m_owner);
-        delete temp;
+        while (!empty() && (top()->GetMovementGeneratorType() == CHASE_MOTION_TYPE || top()->GetMovementGeneratorType() == FOLLOW_MOTION_TYPE))
+        {
+            MovementGenerator* temp = top();
+            pop();
+            temp->Finalize(*m_owner);
+            delete temp;
+        }
     }
 
     // Store current top MMGen, as Finalize might push a new MMGen
@@ -290,13 +294,17 @@ void MotionMaster::DelayedExpire(bool reset)
         m_expList = new ExpireList();
     }
 
-    // Also drop stored under top() targeted motions
-    while (!empty() && (top()->GetMovementGeneratorType() == CHASE_MOTION_TYPE || top()->GetMovementGeneratorType() == FOLLOW_MOTION_TYPE))
+    // Also drop stored under top() targeted motions -- except beneath a transient effect
+    // (a jump, a knockback), which resumes whatever it interrupted.
+    if (curr->GetMovementGeneratorType() != EFFECT_MOTION_TYPE)
     {
-        MovementGenerator* temp = top();
-        pop();
-        temp ->Finalize(*m_owner);
-        m_expList->push_back(temp);
+        while (!empty() && (top()->GetMovementGeneratorType() == CHASE_MOTION_TYPE || top()->GetMovementGeneratorType() == FOLLOW_MOTION_TYPE))
+        {
+            MovementGenerator* temp = top();
+            pop();
+            temp->Finalize(*m_owner);
+            m_expList->push_back(temp);
+        }
     }
 
     curr->Finalize(*m_owner);
@@ -618,6 +626,14 @@ void MotionMaster::Mutate(MovementGenerator* m)
             case DISTRACT_MOTION_TYPE:
             case EFFECT_MOTION_TYPE:
                 MovementExpired(false);
+                // The expiry keeps a chase or follow beneath an effect, for the effect that
+                // ends by itself. This one is being replaced: drop them, as before, or every
+                // knockback and re-chase would pile a chase on the last one.
+                while (size() > 1 && (top()->GetMovementGeneratorType() == CHASE_MOTION_TYPE ||
+                                      top()->GetMovementGeneratorType() == FOLLOW_MOTION_TYPE))
+                {
+                    MovementExpired(false);
+                }
             default:
                 break;
         }

--- a/src/game/MotionGenerators/MovementIntent.h
+++ b/src/game/MotionGenerators/MovementIntent.h
@@ -193,7 +193,9 @@ namespace Motion
     struct MoveStatus
     {
         bool    traveling = false; ///< A leg is running right now.
-        bool    arrived = false;   ///< The leg finished (once).
+        bool    arrived = false;   ///< The leg ran out AT its goal (once).
+        bool    cut = false;       ///< The leg was stopped or interrupted short of its goal (once).
+        bool    partial = false;   ///< The leg ran out short of its goal because its route only got partway (once): re-state the goal to go on.
         bool    blocked = false;   ///< The last Move could not be laid (once).
         int32   pathIndex = 0;     ///< How far along its points the spline is.
         Vector3 legGoal;           ///< The goal of the leg the driver actually laid.

--- a/src/game/MotionGenerators/PathFinder.cpp
+++ b/src/game/MotionGenerators/PathFinder.cpp
@@ -562,6 +562,14 @@ void PathFinder::BuildPointPath(const float* startPoint, const float* endPoint)
     // first point is always our current location - we need the next one
     setActualEndPosition(m_pathPoints[pointCount - 1]);
 
+    // the point path can stop short of the requested end (iteration cap or
+    // steering failure) even when the poly corridor reached the end poly -
+    // never report such a truncated path as complete
+    if ((m_type & PATHFIND_NORMAL) && !inRange(getActualEndPosition(), getEndPosition(), 3.0f, 7.5f))
+    {
+        m_type = PATHFIND_INCOMPLETE;
+    }
+
     // force the given destination, if needed
     if (m_forceDestination &&
         (!(m_type & PATHFIND_NORMAL) || !inRange(getEndPosition(), getActualEndPosition(), 1.0f, 1.0f)))
@@ -849,6 +857,7 @@ dtStatus PathFinder::findSmoothPath(const float* startPos, const float* endPos,
 {
     *smoothPathSize = 0;
     uint32 nsmoothPath = 0;
+    bool reachedEnd = false;
 
     dtPolyRef polys[MAX_PATH_LENGTH];
     memcpy(polys, polyPath, sizeof(dtPolyRef)*polyPathSize);
@@ -921,6 +930,7 @@ dtStatus PathFinder::findSmoothPath(const float* startPos, const float* endPos,
         if (endOfPath && inRangeYZX(iterPos, steerPos, SMOOTH_PATH_SLOP, 1.0f))
         {
             // Reached end of path.
+            reachedEnd = true;
             dtVcopy(iterPos, targetPos);
             if (nsmoothPath < maxSmoothPathSize)
             {
@@ -980,8 +990,11 @@ dtStatus PathFinder::findSmoothPath(const float* startPos, const float* endPos,
 
     *smoothPathSize = nsmoothPath;
 
-    // Return success if the smooth path size is within the maximum limit.
-    return nsmoothPath < MAX_POINT_PATH_LENGTH ? DT_SUCCESS : DT_FAILURE;
+    // A full buffer that never reached the end is a truncated route, not a failed one:
+    // BuildPointPath marks it INCOMPLETE from its geometry and the mover walks it as far
+    // as it goes, then re-paths from there.
+    return (reachedEnd || nsmoothPath < maxSmoothPathSize) ? DT_SUCCESS
+                                                         : (DT_SUCCESS | DT_BUFFER_TOO_SMALL);
 }
 
 /**

--- a/src/game/MotionGenerators/PointMovementGenerator.cpp
+++ b/src/game/MotionGenerators/PointMovementGenerator.cpp
@@ -122,6 +122,14 @@ Motion::MoveIntent PointMovementGenerator::Intent(Unit& owner,
         return Motion::MoveIntent::Done();
     }
 
+    // Stopped or interrupted from outside: the move is over. Tell the script anyway, so a
+    // sequence waiting on this point does not stall; the point is wherever we stand now.
+    if (status.cut)
+    {
+        m_done = true;
+        return Motion::MoveIntent::Done();
+    }
+
     owner.addUnitState(UNIT_STAT_ROAMING | UNIT_STAT_ROAMING_MOVE);
 
     // m_dest arrived from a script, an AI or a spell effect, and those speak WORLD
@@ -155,7 +163,16 @@ Motion::MoveIntent EffectMovementGenerator::Intent(Unit& /*owner*/,
     // Note this is `traveling`, not `arrived`: the spline was launched by the effect, not
     // by us, so if it was never running at all we must pop immediately rather than wait
     // for an arrival edge that will never come.
-    return status.traveling ? Motion::MoveIntent::Hold() : Motion::MoveIntent::Done();
+    if (status.traveling)
+    {
+        return Motion::MoveIntent::Hold();
+    }
+
+    // The spline is over -- run out, cut short, or never launched: report it. A script
+    // waiting on a jump must not stall; the landing is wherever the unit stands now.
+    // (Popped mid-flight by Clear or Mutate, nothing has ended and nothing is reported.)
+    m_done = true;
+    return Motion::MoveIntent::Done();
 }
 
 void EffectMovementGenerator::Finalize(Unit& owner)
@@ -167,7 +184,11 @@ void EffectMovementGenerator::Finalize(Unit& owner)
 
     Creature& creature = static_cast<Creature&>(owner);
 
-    if (creature.AI() && owner.movespline->Finalized())
+    // Ended on our own tick, or landed while we were not ticking at all (a stun): both
+    // are the effect having happened. A spline still flying, or one cut short by the
+    // generator that replaces us, is not.
+    const bool landed = owner.movespline->Finalized() && !owner.movespline->Cut();
+    if (creature.AI() && (m_done || landed))
     {
         creature.AI()->MovementInform(EFFECT_MOTION_TYPE, m_id);
     }

--- a/src/game/MotionGenerators/PointMovementGenerator.cpp
+++ b/src/game/MotionGenerators/PointMovementGenerator.cpp
@@ -199,7 +199,14 @@ void EffectMovementGenerator::Finalize(Unit& owner)
         return;
     }
 
-    // Expiring drops the chase beneath us, so re-lay it; anything else beneath resumes by itself.
+    // Whatever we interrupted resumes by itself -- a chase or follow included, which expiry
+    // now leaves beneath us. Only a victim with no chase left to resume gets a fresh one.
+    const MovementGeneratorType beneath = owner.GetMotionMaster()->GetCurrentMovementGeneratorType();
+    if (beneath == CHASE_MOTION_TYPE || beneath == FOLLOW_MOTION_TYPE)
+    {
+        return;
+    }
+
     if (Unit* victim = owner.getVictim())
     {
         owner.GetMotionMaster()->MoveChase(victim);

--- a/src/game/MotionGenerators/PointMovementGenerator.h
+++ b/src/game/MotionGenerators/PointMovementGenerator.h
@@ -129,7 +129,8 @@ class EffectMovementGenerator final : public IntentMovementGenerator
                                   uint32 diff) override;
 
     private:
-        uint32 m_id; ///< Echoed to the AI when the effect's spline ends.
+        uint32 m_id;         ///< Echoed to the AI when the effect's spline ends.
+        bool m_done = false; ///< The effect's spline ran its course.
 };
 
 #endif // MANGOS_POINTMOVEMENTGENERATOR_H

--- a/src/game/MotionGenerators/TargetedMovementGenerator.cpp
+++ b/src/game/MotionGenerators/TargetedMovementGenerator.cpp
@@ -122,6 +122,7 @@ Motion::MoveIntent TargetedMovementGenerator::Intent(Unit& owner,
 
     if (blockedByState)
     {
+        m_relay = m_relay || status.partial || status.cut;
         ClearMoveState(owner);
         return Motion::MoveIntent::Hold();
     }
@@ -129,6 +130,7 @@ Motion::MoveIntent TargetedMovementGenerator::Intent(Unit& owner,
     // No shuffling out from under a cast with a cast time or a channel.
     if (owner.IsNonMeleeSpellCasted(false, false, true))
     {
+        m_relay = m_relay || status.partial || status.cut;
         if (!owner.IsStopped())
         {
             owner.StopMoving();
@@ -147,7 +149,21 @@ Motion::MoveIntent TargetedMovementGenerator::Intent(Unit& owner,
     if (m_recheckTime.Passed())
     {
         m_recheckTime.Reset(RecheckIntervalMs());
-        needDest = RequiresNewPosition(owner, status.legGoal);
+        needDest = needDest || RequiresNewPosition(owner, status.legGoal);
+    }
+
+    // The leg ran out at the far end of a partial route, or was cut short by a stop:
+    // go on from here rather than standing on a spot we never reached. The edge is
+    // latched, because it may arrive on a tick that holds (a cast, a control state).
+    if (status.partial || status.cut)
+    {
+        m_relay = true;
+    }
+
+    if (m_relay)
+    {
+        m_relay = false;
+        needDest = true;
     }
 
     if (needDest)
@@ -159,7 +175,7 @@ Motion::MoveIntent TargetedMovementGenerator::Intent(Unit& owner,
     }
 
     // The leg ended (or none was ever needed): we are as close as we asked to be.
-    if (!status.traveling && !m_targetReached)
+    if (!status.traveling && !m_targetReached && !status.partial)
     {
         m_targetReached = true;
         ReachTarget(owner);

--- a/src/game/MotionGenerators/TargetedMovementGenerator.h
+++ b/src/game/MotionGenerators/TargetedMovementGenerator.h
@@ -113,6 +113,7 @@ class TargetedMovementGenerator : public IntentMovementGenerator,
         Motion::Vector3 m_dest;       ///< The standing spot we are heading for.
         bool m_haveDest = false;      ///< False before the first spot has been derived.
         bool m_targetReached = false; ///< ReachTarget already fired for this approach.
+        bool m_relay = false;         ///< A cut or partial leg ended: derive a fresh spot on the next tick that moves.
 };
 
 /**

--- a/src/game/MotionGenerators/WaypointMovementGenerator.cpp
+++ b/src/game/MotionGenerators/WaypointMovementGenerator.cpp
@@ -456,6 +456,7 @@ Motion::MoveIntent WaypointMovementGenerator::WalkPreparedLeg() const
 Motion::MoveIntent WaypointMovementGenerator::PrepareMove(Creature& creature)
 {
     m_haveLeg = false;
+    m_approached = false;
     m_legPoints.clear();
 
     if (!m_path || m_path->empty() || Stopped(creature))
@@ -564,7 +565,7 @@ Motion::MoveIntent WaypointMovementGenerator::Intent(Unit& owner,
 
     // There was no way to reach the node we aimed at. Count it as arrived so the patrol
     // steps over it, rather than butting into it forever.
-    if (status.blocked)
+    if (status.blocked && !m_approached)
     {
         ClearSegment();
         m_isArrivalDone = true;
@@ -598,10 +599,23 @@ Motion::MoveIntent WaypointMovementGenerator::Intent(Unit& owner,
         return PrepareMove(creature);
     }
 
+    // The leg ran out at the far end of a partial route: re-state it and walk on. The node
+    // has not been reached, whatever the finalized spline says.
+    if (status.partial && m_haveLeg)
+    {
+        m_approached = true;
+        return WalkPreparedLeg();
+    }
+
+    // A route got partway to the node and from its end there is no way on: the node is
+    // as reached as it gets. Arrive there, so its script, delay and inform still run.
+    const bool asCloseAsItGets = status.blocked && m_approached;
+
     // Sample the stopped state BEFORE arrival handling clears UNIT_STAT_ROAMING_MOVE, so an
     // externally force-stopped unit (a player talking to it, which also finalizes the
     // spline) is paused rather than mistaken for a leg that simply finished.
-    switch (GetWaypointSegmentUpdateState(!status.traveling, creature.IsStopped()))
+    switch (asCloseAsItGets ? WaypointSegmentUpdateState::Finalized
+                            : GetWaypointSegmentUpdateState(!status.traveling, creature.IsStopped()))
     {
         case WaypointSegmentUpdateState::Stopped:
             ClearSegment();

--- a/src/game/MotionGenerators/WaypointMovementGenerator.h
+++ b/src/game/MotionGenerators/WaypointMovementGenerator.h
@@ -199,6 +199,7 @@ class WaypointMovementGenerator final : public IntentMovementGenerator
         bool m_haveLeg = false;
         uint32 m_deadNodes = 0;      ///< Nodes skipped as unreachable in a row.
         bool m_forceNextLeg = false; ///< Walk the next leg unrouted: a whole lap was unreachable.
+        bool m_approached = false; ///< A partial leg toward the node was walked: a block now is as close as it gets.
 };
 
 /**

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -6792,7 +6792,12 @@ void Unit::UpdateSplineMovement(uint32 t_diff)
 void Unit::DisableSpline()
 {
     m_movementInfo.RemoveMovementFlag(MovementFlags(MOVEFLAG_SPLINE_ENABLED | MOVEFLAG_FORWARD));
-    movespline->_Interrupt();
+
+    // A spline that ran out is finished, not cut; only a live one is interrupted here.
+    if (!movespline->Finalized())
+    {
+        movespline->_Interrupt();
+    }
 }
 
 void Unit::SendCollisionHeightUpdate(float height)

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -448,6 +448,32 @@ void Unit::Update(uint32 update_diff, uint32 p_time)
     ModifyAuraState(AURA_STATE_HEALTHLESS_20_PERCENT, GetHealth() < GetMaxHealth() * 0.20f);
     ModifyAuraState(AURA_STATE_HEALTHLESS_35_PERCENT, GetHealth() < GetMaxHealth() * 0.35f);
     ModifyAuraState(AURA_STATE_HEALTH_ABOVE_75_PERCENT, GetHealth() > GetMaxHealth() * 0.75f);
+    // A stop took the spline's position: write it now, where a cell switch is safe --
+    // unless something else moved the unit since.
+    if (m_hasPendingCommit)
+    {
+        m_hasPendingCommit = false;
+        if (Where().X() == m_pendingCommitFrom.x && Where().Y() == m_pendingCommitFrom.y &&
+            Where().Z() == m_pendingCommitFrom.z && Where().Facing() == m_pendingCommitFrom.o)
+        {
+            if (GetTypeId() == TYPEID_PLAYER)
+            {
+                ((Player*)this)->SetPosition(m_pendingCommit.x, m_pendingCommit.y,
+                                             m_pendingCommit.z, m_pendingCommit.o);
+            }
+            else
+            {
+                GetMap()->CreatureRelocation((Creature*)this, m_pendingCommit.x, m_pendingCommit.y,
+                                             m_pendingCommit.z, m_pendingCommit.o);
+            }
+
+            // The movement state follows the placement whenever the server is the one that
+            // moved the unit, so the next create block agrees with where it was stopped.
+            m_movementInfo.Report(m_pendingCommit.x, m_pendingCommit.y,
+                                  m_pendingCommit.z, m_pendingCommit.o);
+        }
+    }
+
     UpdateSplineMovement(p_time);
     i_motionMaster.UpdateMotion(p_time);
 }
@@ -5649,13 +5675,12 @@ void Unit::StopMoving(bool forceSendStop /*=false*/)
         return;
     }
 
-    // Commit where the spline actually is before stopping there, so the server, the stop
-    // packet and every later create block agree. A commit refused at a cell edge leaves
-    // the last committed position, and the stop is placed there instead.
-    const bool committed = CommitSplinePosition();
+    // Take where the spline actually is before stopping there, so the stop packet and
+    // the placement agree. The placement itself is written on the next Update.
+    CommitSplinePosition();
 
     Movement::MoveSplineInit init(*this);
-    init.Stop(!committed);
+    init.Stop();
 }
 
 /**
@@ -5689,21 +5714,13 @@ bool Unit::CommitSplinePosition()
         return true;
     }
 
-    // A bare placement write must not cross a cell: the grid would still list the unit
-    // in the old one. Keep the last committed position then, and let the next real
-    // relocation carry it over.
-    CellPair const curCell = MaNGOS::ComputeCellPair(Where().X(), Where().Y());
-    CellPair const newCell = MaNGOS::ComputeCellPair(loc.x, loc.y);
-    if (curCell != newCell)
-    {
-        return false;
-    }
-
-    Place().MoveTo(loc.x, loc.y, loc.z, loc.orientation);
-
-    // The movement state follows the placement whenever the server is the one that moved
-    // the unit, so the next create block agrees with where it was stopped.
-    m_movementInfo.Report(loc.x, loc.y, loc.z, loc.orientation);
+    // The placement is written on the next Update. A stop can come from inside a grid
+    // visit (an AI reacting to what just walked into view), where a cell switch would
+    // break the list being walked; Update is the one place it is safe. Where the unit
+    // stands now is kept, so a relocation by anything else in between is not undone.
+    m_pendingCommit = Position(loc.x, loc.y, loc.z, loc.orientation);
+    m_pendingCommitFrom = Position(Where().X(), Where().Y(), Where().Z(), Where().Facing());
+    m_hasPendingCommit = true;
     return true;
 }
 

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -5627,11 +5627,6 @@ void Unit::SendPetAIReaction()
 
 void Unit::StopMoving(bool forceSendStop /*=false*/)
 {
-    if (IsStopped() && !forceSendStop)
-    {
-        return;
-    }
-
     clearUnitState(UNIT_STAT_MOVING);
 
     // not need send any packets if not in world
@@ -5640,8 +5635,27 @@ void Unit::StopMoving(bool forceSendStop /*=false*/)
         return;
     }
 
+    // Gate on the spline, not on the *_MOVE states: home legs, effects and raw script
+    // splines set none, and skipping them left the spline running.
+    if (movespline->Finalized() && !forceSendStop)
+    {
+        return;
+    }
+
+    // A jump or a fall is ballistic: it cannot stop mid-air, so it is left to land and
+    // its effect ends there. Only an interrupt (forced) cuts it.
+    if (movespline->Airborne() && !forceSendStop)
+    {
+        return;
+    }
+
+    // Commit where the spline actually is before stopping there, so the server, the stop
+    // packet and every later create block agree. A commit refused at a cell edge leaves
+    // the last committed position, and the stop is placed there instead.
+    const bool committed = CommitSplinePosition();
+
     Movement::MoveSplineInit init(*this);
-    init.Stop();
+    init.Stop(!committed);
 }
 
 /**
@@ -5651,22 +5665,46 @@ void Unit::StopMoving(bool forceSendStop /*=false*/)
  */
 void Unit::InterruptMoving(bool forceSendStop /*=false*/)
 {
-    bool isMoving = false;
+    // One stop path: commit the in-flight position and finalize through Stop(), which
+    // sends the stop packet and leaves a spline the driver reads as cut, not arrived.
+    StopMoving(forceSendStop || !movespline->Finalized());
+}
 
-    if (!movespline->Finalized())
+bool Unit::CommitSplinePosition()
+{
+    if (movespline->Finalized())
     {
-        Movement::Location loc = movespline->ComputePosition();
-        movespline->_Interrupt();
-        Place().MoveTo(loc.x, loc.y, loc.z, loc.orientation);
-
-        // The stop packet below, and every create block until the client speaks again, are
-        // written from the movement state -- so it follows the placement whenever the
-        // server is the one that moved the unit.
-        m_movementInfo.Report(loc.x, loc.y, loc.z, loc.orientation);
-        isMoving = true;
+        return false;
     }
 
-    StopMoving(forceSendStop || isMoving);
+    Movement::Location loc = movespline->ComputePosition();
+
+    if (IsBoarded())
+    {
+        // Boarded spline coordinates are seat-local: update the seat pose
+        Geometry::Placement deckPose;
+        deckPose.EnterFrame(GetTransportInfo()->Seat().CurrentFrame(),
+                            Geometry::Vector3(loc.x, loc.y, loc.z), loc.orientation);
+        GetTransportInfo()->SetSeatPose(deckPose);
+        return true;
+    }
+
+    // A bare placement write must not cross a cell: the grid would still list the unit
+    // in the old one. Keep the last committed position then, and let the next real
+    // relocation carry it over.
+    CellPair const curCell = MaNGOS::ComputeCellPair(Where().X(), Where().Y());
+    CellPair const newCell = MaNGOS::ComputeCellPair(loc.x, loc.y);
+    if (curCell != newCell)
+    {
+        return false;
+    }
+
+    Place().MoveTo(loc.x, loc.y, loc.z, loc.orientation);
+
+    // The movement state follows the placement whenever the server is the one that moved
+    // the unit, so the next create block agrees with where it was stopped.
+    m_movementInfo.Report(loc.x, loc.y, loc.z, loc.orientation);
+    return true;
 }
 
 

--- a/src/game/Object/Unit.h
+++ b/src/game/Object/Unit.h
@@ -3977,6 +3977,7 @@ uint32  GetPower(Powers power) const { return GetUInt32Value(UNIT_FIELD_POWER1 +
         bool IsStopped() const { return !(hasUnitState(UNIT_STAT_MOVING)); }
         void StopMoving(bool forceSendStop = false);
         void InterruptMoving(bool forceSendStop = false);
+        bool CommitSplinePosition(); ///< Write the running spline's position into the placement; false when it would cross a cell.
 
         void SetFeared(bool apply, ObjectGuid casterGuid = ObjectGuid(), uint32 spellID = 0, uint32 time = 0);
         void SetConfused(bool apply, ObjectGuid casterGuid = ObjectGuid(), uint32 spellID = 0);

--- a/src/game/Object/Unit.h
+++ b/src/game/Object/Unit.h
@@ -3977,7 +3977,8 @@ uint32  GetPower(Powers power) const { return GetUInt32Value(UNIT_FIELD_POWER1 +
         bool IsStopped() const { return !(hasUnitState(UNIT_STAT_MOVING)); }
         void StopMoving(bool forceSendStop = false);
         void InterruptMoving(bool forceSendStop = false);
-        bool CommitSplinePosition(); ///< Write the running spline's position into the placement; false when it would cross a cell.
+        bool CommitSplinePosition(); ///< Take the running spline's position: the seat pose at once, the placement on the next Update. False when no spline runs.
+        Position const* PendingSplineCommit() const { return m_hasPendingCommit ? &m_pendingCommit : NULL; } ///< A stop's position the placement has not caught up with yet.
 
         void SetFeared(bool apply, ObjectGuid casterGuid = ObjectGuid(), uint32 spellID = 0, uint32 time = 0);
         void SetConfused(bool apply, ObjectGuid casterGuid = ObjectGuid(), uint32 spellID = 0);
@@ -4103,6 +4104,10 @@ uint32  GetPower(Powers power) const { return GetUInt32Value(UNIT_FIELD_POWER1 +
         Position m_last_notified_position;
         bool m_AINotifyScheduled;
         TimeTracker m_movesplineTimer;
+
+        Position m_pendingCommit;     ///< A stop's spline position, written on the next Update.
+        Position m_pendingCommitFrom; ///< The placement when it was taken; a change since means someone else moved the unit.
+        bool m_hasPendingCommit = false;
 
         Diminishing m_Diminishing;
         // Manage all Units threatening us

--- a/src/game/movement/MoveSpline.cpp
+++ b/src/game/movement/MoveSpline.cpp
@@ -222,6 +222,7 @@ namespace Movement
     void MoveSpline::Initialize(const MoveSplineInitArgs& args)
     {
         splineflags = args.flags;
+        m_cut = args.flags.done; // a stop spline is born finished: that is a cut, not an arrival
         facing = args.facing;
         m_Id = args.splineId;
         point_Idx_offset = args.path_Idx_offset;

--- a/src/game/movement/MoveSpline.h
+++ b/src/game/movement/MoveSpline.h
@@ -118,6 +118,7 @@ namespace Movement
             int32           effect_start_time;
             int32           point_Idx; /**< Current point index in the spline. */
             int32           point_Idx_offset; /**< Offset for the point index. */
+            bool            m_cut = false;    /**< Ended early: interrupted, or initialized already done (a stop). */
 
             /**
              * @brief Initializes the spline with the given arguments.
@@ -191,7 +192,7 @@ namespace Movement
             /**
              * @brief Interrupts the spline.
              */
-            void _Interrupt() { splineflags.done = true;}
+            void _Interrupt() { splineflags.done = true; m_cut = true; }
 
         public:
             /**
@@ -255,6 +256,10 @@ namespace Movement
              * @return bool True if the spline is finalized, false otherwise.
              */
             bool Finalized() const { return splineflags.done; }
+            /// Ended early -- interrupted, or born already done as a stop -- rather than run out.
+            bool Cut() const { return m_cut; }
+            /// Ballistic -- a jump or a fall -- which cannot stop mid-air.
+            bool Airborne() const { return splineflags.parabolic || splineflags.falling; }
 
             /**
              * @brief Checks if the spline is cyclic.

--- a/src/game/movement/MoveSplineInit.cpp
+++ b/src/game/movement/MoveSplineInit.cpp
@@ -200,7 +200,7 @@ namespace Movement
     /**
      * @brief Stops any creature movement.
      */
-    void MoveSplineInit::Stop()
+    void MoveSplineInit::Stop(bool atCommittedPosition /*= false*/)
     {
         MoveSpline& move_spline = *unit.movespline;
 
@@ -231,7 +231,9 @@ namespace Movement
 
         // there is a big chance that current position is unknown if current state is not finalized, need compute it
         // this also allows calculate spline position and update map position in much greater intervals
-        if (!move_spline.Finalized() && !transportInfo)
+        // ... unless the caller could not commit that position (a cell edge): then the
+        // stop is placed where the unit is known to stand, so the packet and the server agree.
+        if (!move_spline.Finalized() && !transportInfo && !atCommittedPosition)
         {
             real_position = move_spline.ComputePosition();
         }

--- a/src/game/movement/MoveSplineInit.cpp
+++ b/src/game/movement/MoveSplineInit.cpp
@@ -133,6 +133,15 @@ namespace Movement
         {
             real_position = move_spline.ComputePosition();
         }
+        else if (!transportInfo)
+        {
+            // A stop just took the spline's position and the placement has not caught up
+            // (it is written on the unit's next Update): start from where the stop was sent.
+            if (Position const* pending = unit.PendingSplineCommit())
+            {
+                real_position = Location(pending->x, pending->y, pending->z, pending->o);
+            }
+        }
 
         if (args.path.empty())
         {
@@ -200,7 +209,7 @@ namespace Movement
     /**
      * @brief Stops any creature movement.
      */
-    void MoveSplineInit::Stop(bool atCommittedPosition /*= false*/)
+    void MoveSplineInit::Stop()
     {
         MoveSpline& move_spline = *unit.movespline;
 
@@ -231,9 +240,7 @@ namespace Movement
 
         // there is a big chance that current position is unknown if current state is not finalized, need compute it
         // this also allows calculate spline position and update map position in much greater intervals
-        // ... unless the caller could not commit that position (a cell edge): then the
-        // stop is placed where the unit is known to stand, so the packet and the server agree.
-        if (!move_spline.Finalized() && !transportInfo && !atCommittedPosition)
+        if (!move_spline.Finalized() && !transportInfo)
         {
             real_position = move_spline.ComputePosition();
         }

--- a/src/game/movement/MoveSplineInit.h
+++ b/src/game/movement/MoveSplineInit.h
@@ -63,7 +63,7 @@ namespace Movement
             /**
              * @brief Stops any creature movement.
              */
-            void Stop();
+            void Stop(bool atCommittedPosition = false);
 
             /* Adds movement by parabolic trajectory
              * @param amplitude  - the maximum height of parabola, value could be negative and positive

--- a/src/game/movement/MoveSplineInit.h
+++ b/src/game/movement/MoveSplineInit.h
@@ -63,7 +63,7 @@ namespace Movement
             /**
              * @brief Stops any creature movement.
              */
-            void Stop(bool atCommittedPosition = false);
+            void Stop();
 
             /* Adds movement by parabolic trajectory
              * @param amplitude  - the maximum height of parabola, value could be negative and positive


### PR DESCRIPTION
Replaces #263 (path cap) and #264 (StopMoving gate), which the review blocked for the same root cause: the driver treated *any* finished spline as an arrival.

**Tell a cut or partial leg from an arrival.** `MoveSpline` records that it was cut (a stop or an interrupt; a spline that ran out is not a cut); the driver records that its route was partial. `MoveStatus` gains `cut` and `partial` next to `arrived`. A cut Point/Path leg ends and still informs, so a script waiting on it does not stall. Home and Chase/Follow re-state their goal after a cut instead of holding where the stop landed; a partial leg walks on from where the route ended; a partial route that moves the unit under a yard, or a spline `Launch()` refuses, is `blocked`, so nothing re-lays a zero-length leg every tick. A waypoint node whose route gets partway and then no further is arrived at there, so its script, delay and inform still run. `findSmoothPath` reports a full buffer that never reached the end as `DT_SUCCESS | DT_BUFFER_TOO_SMALL` and `BuildPointPath` marks the route `PATHFIND_INCOMPLETE` from its geometry (mangostwo gets the check mangosthree already had); a raw `MoveTo(generatePath)` over such a route walks its first 74 points instead of a straight-line shortcut. A 372-yd `MovePoint` now reaches its point and informs there.

**One stop path.** `StopMoving` gates on the spline, not on the `*_MOVE` states; `InterruptMoving` no longer finalizes before stopping. Both take the spline's live position, then `Stop()` finalizes and sends the stop at it. A boarded unit's seat pose is updated at once; everyone else's placement is written on the unit's next `Update`, the one place a grid cell switch is safe (a stop can come from inside a grid visit, and the visitors other than the creature updater are not cache-next safe), and the pending write is dropped if anything else relocated the unit in between. `Stop()` keeps its upstream signature. A jump or a fall is ballistic and is left to land; its effect ends there.

**Effects keep the chase/follow beneath.** `DirectExpire`/`DelayedExpire` no longer drop a CHASE/FOLLOW under an effect that ends by itself; `Mutate` still drops them when it replaces the effect, so chases do not pile up.

Depends on #261 (effect ordering) and #265 (point inform); their commits are included here and drop out on rebase once they merge. Overlaps #267 by one header line (`WaypointMovementGenerator.h`): whichever merges second needs a one-line rebase.

Verified headless on the live 4.3.4 build, red on the old code and green here: the 372-yd `MovePoint` informs at its point (was 83 yd short); a stop mid-home resumes and finishes homing; a stun during a jump lets it land and inform there; back-to-back jumps complete and inform; a knocked-back follower keeps following; a point 7 yd above the mesh informs from beneath it instead of re-laying a zero-length spline forever; the earlier suite still passes. Reviewed adversarially (agent passes and a Codex debate) and compiled from a clean clone. Same code in mangosthree: paired PR.

Paired with mangosthree/server#349.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/268)
<!-- Reviewable:end -->

