### PR TITLE
[Movement] Harden the route cache and the suffix rebuild

### DIFF
--- a/src/game/MotionGenerators/MotionDriver.cpp
+++ b/src/game/MotionGenerators/MotionDriver.cpp
@@ -57,11 +57,16 @@ Motion::IPathQuery* MotionDriver::Query(Unit const& owner)
     Motion::IMotionFrame const& frame = Motion::FrameFor(owner);
 
     // A leg never spans two frames: if the mover changed frame since the last leg, the
-    // old router speaks the wrong coordinate system.
-    if (!m_query || m_queryFrame != frame.Kind())
+    // old router speaks the wrong coordinate system. Nor two maps: the router binds the
+    // map's mesh and the instance's query at construction, and a generator outlives a
+    // teleport.
+    if (!m_query || m_queryFrame != frame.Kind() ||
+        m_queryMapId != owner.GetMapId() || m_queryInstanceId != owner.GetInstanceId())
     {
         m_query = frame.CreatePathQuery(owner);
         m_queryFrame = frame.Kind();
+        m_queryMapId = owner.GetMapId();
+        m_queryInstanceId = owner.GetInstanceId();
     }
 
     return m_query.get();

--- a/src/game/MotionGenerators/MotionDriver.h
+++ b/src/game/MotionGenerators/MotionDriver.h
@@ -87,6 +87,8 @@ class MotionDriver
 
         std::unique_ptr<Motion::IPathQuery> m_query;
         Motion::FrameKind m_queryFrame = Motion::FrameKind::World;
+        uint32 m_queryMapId = 0;      ///< The map the router was built for.
+        uint32 m_queryInstanceId = 0; ///< And the instance: the mesh query is per instance.
 
         /// The goal of the leg we last laid, so the drift test can tell when a tracked
         /// destination has moved far enough to be worth re-routing.

--- a/src/game/MotionGenerators/PathFinder.cpp
+++ b/src/game/MotionGenerators/PathFinder.cpp
@@ -50,18 +50,28 @@ PathFinder::PathFinder(const Unit* owner) :
 PathFinder::PathFinder(const Unit* owner, uint32 mapId) :
     m_polyLength(0), m_type(PATHFIND_BLANK),
     m_useStraightPath(false), m_forceDestination(false), m_pointPathLimit(MAX_POINT_PATH_LENGTH),
-    m_sourceUnit(owner), m_navMesh(NULL), m_navMeshQuery(NULL)
+    m_sourceUnit(owner), m_mapId(mapId), m_navMesh(NULL), m_navMeshQuery(NULL)
 {
     DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ PathFinder::PathInfo for %u \n", m_sourceUnit->GetGUIDLow());
 
-    if (MMAP::MMapFactory::IsPathfindingEnabled(mapId))
+    BindMesh();
+    createFilter();
+}
+
+void PathFinder::BindMesh()
+{
+    // Looked up afresh before every route: a PathFinder can outlive its map (a generator
+    // survives a teleport), and an instance torn down and recreated under the same ids
+    // gets a new query while a pointer taken earlier would point at freed memory.
+    m_navMesh = NULL;
+    m_navMeshQuery = NULL;
+
+    if (MMAP::MMapFactory::IsPathfindingEnabled(m_mapId))
     {
         MMAP::MMapManager* mmap = MMAP::MMapFactory::createOrGetMMapManager();
-        m_navMesh = mmap->GetNavMesh(mapId);
-        m_navMeshQuery = mmap->GetNavMeshQuery(mapId, m_sourceUnit->GetInstanceId());
+        m_navMesh = mmap->GetNavMesh(m_mapId);
+        m_navMeshQuery = mmap->GetNavMeshQuery(m_mapId, m_sourceUnit->GetInstanceId());
     }
-
-    createFilter();
 }
 
 /**
@@ -116,6 +126,8 @@ bool PathFinder::calculate(float startX, float startY, float startZ, float destX
     m_forceDestination = forceDest;
 
     DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ PathFinder::calculate() for %u \n", m_sourceUnit->GetGUIDLow());
+
+    BindMesh();
 
     // make sure navMesh works - we can run on map w/o mmap
     // check if the start and end point have a .mmtile loaded (can we pass via not loaded tile on the way?)
@@ -371,6 +383,9 @@ void PathFinder::BuildPolyPath(const Vector3& startPos, const Vector3& endPos)
         }
     }
 
+    // No usable prefix: the first run, or we are no longer on the old path.
+    bool rebuild = !startPolyFound;
+
     if (startPolyFound && endPolyFound)
     {
         DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ BuildPolyPath :: (startPolyFound && endPolyFound)\n");
@@ -406,50 +421,49 @@ void PathFinder::BuildPolyPath(const Vector3& startPos, const Vector3& endPos)
         // we need any point on our suffix start poly to generate poly-path, so we need last poly in prefix data
         float suffixEndPoint[VERTEX_SIZE];
         dtResult = m_navMeshQuery->closestPointOnPoly(suffixStartPoly, endPoint, suffixEndPoint, NULL);
-        if (dtStatusFailed(dtResult))
+        if (dtStatusFailed(dtResult) && prefixPolyLength > 1)
         {
             // we can hit offmesh connection as last poly - closestPointOnPoly() don't like that
             // try to recover by using prev polyref
             --prefixPolyLength;
             suffixStartPoly = m_pathPolyRefs[prefixPolyLength - 1];
             dtResult = m_navMeshQuery->closestPointOnPoly(suffixStartPoly, endPoint, suffixEndPoint, NULL);
-            if (dtStatusFailed(dtResult))
-            {
-                // suffixStartPoly is still invalid, error state
-                BuildShortcut();
-                m_type = PATHFIND_NOPATH;
-                return;
-            }
         }
 
         // generate suffix
         uint32 suffixPolyLength = 0;
-        dtResult = m_navMeshQuery->findPath(
-                       suffixStartPoly,    // start polygon
-                       endPoly,            // end polygon
-                       suffixEndPoint,     // start position
-                       endPoint,           // end position
-                       &m_filter,            // polygon search filter
-                       m_pathPolyRefs + prefixPolyLength - 1,    // [out] path
-                       (int*)&suffixPolyLength,
-                       MAX_PATH_LENGTH - prefixPolyLength); // max number of polygons in output path
+        if (dtStatusSucceed(dtResult))
+        {
+            dtResult = m_navMeshQuery->findPath(
+                           suffixStartPoly,    // start polygon
+                           endPoly,            // end polygon
+                           suffixEndPoint,     // start position
+                           endPoint,           // end position
+                           &m_filter,            // polygon search filter
+                           m_pathPolyRefs + prefixPolyLength - 1,    // [out] path
+                           (int*)&suffixPolyLength,
+                           MAX_PATH_LENGTH - prefixPolyLength); // max number of polygons in output path
+        }
 
         if (!suffixPolyLength || dtStatusFailed(dtResult))
         {
-            // this is probably an error state, but we'll leave it
-            // and hopefully recover on the next Update
-            // we still need to copy our preffix
-            sLog.outError("%u's Path Build failed: 0 length path", m_sourceUnit->GetGUIDLow());
+            // No poly to start the suffix from (an off-mesh link was the whole prefix), or
+            // no suffix at all: the prefix is worthless. Rebuild from scratch below rather
+            // than keep a path of length zero, which the type check would index at -1.
+            rebuild = true;
         }
+        else
+        {
+            DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++  m_polyLength=%u prefixPolyLength=%u suffixPolyLength=%u \n", m_polyLength, prefixPolyLength, suffixPolyLength);
 
-        DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++  m_polyLength=%u prefixPolyLength=%u suffixPolyLength=%u \n", m_polyLength, prefixPolyLength, suffixPolyLength);
-
-        // new path = prefix + suffix - overlap
-        m_polyLength = prefixPolyLength + suffixPolyLength - 1;
+            // new path = prefix + suffix - overlap
+            m_polyLength = prefixPolyLength + suffixPolyLength - 1;
+        }
     }
-     else
+
+    if (rebuild)
     {
-        DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ BuildPolyPath :: (!startPolyFound && !endPolyFound)\n");
+        DEBUG_FILTER_LOG(LOG_FILTER_PATHFINDING, "++ BuildPolyPath :: rebuild\n");
 
         // either we have no path at all -> first run
         // or something went really wrong -> we aren't moving along the path to the target

--- a/src/game/MotionGenerators/PathFinder.h
+++ b/src/game/MotionGenerators/PathFinder.h
@@ -170,6 +170,7 @@ class PathFinder
         Vector3        m_actualEndPosition;// {x, y, z} of the closest possible point to the given destination
 
         const Unit* const       m_sourceUnit;       // The unit that is moving
+        uint32                  m_mapId;            // The map routed on; the mesh is bound per route
         const dtNavMesh*        m_navMesh;          // The navigation mesh
         const dtNavMeshQuery*   m_navMeshQuery;     // The navigation mesh query used to find the path
 
@@ -287,6 +288,8 @@ class PathFinder
          * @brief Create the query filter.
          */
         void createFilter();
+        /// Take the map's mesh and the instance's query from the manager; NULL when there is none.
+        void BindMesh();
 
         /**
          * @brief Update the query filter.


### PR DESCRIPTION
Two hardenings on the routing side of the movement chain, both latent rather than reproduced.

**Rebuild the path when the suffix cannot be grown.** When the target moves off the old poly-path, `BuildPolyPath` keeps ~80% of it and grows a suffix from the last prefix poly. `closestPointOnPoly` rejects an off-mesh link as that poly; the recovery steps back one poly, which with a one-poly prefix is `m_pathPolyRefs[-1]`. A suffix `findPath` that returns nothing was logged and kept, leaving `m_polyLength = prefix - 1`, which is zero for that same prefix and is then indexed at `-1` by the type check. Both now fall through to the full rebuild (the existing `else` branch) instead of a straight-line shortcut or a stale prefix. Same code in TC and both forks; needs an off-mesh link as the whole prefix, so it is rare on our meshes.

**Bind the mesh per route; key the driver's cache on map and instance.** `PathFinder` took the map's mesh and the instance's mesh query once, in its constructor, and `MotionDriver::Query` rebuilt it only when the mover's frame changed: a generator that outlives a teleport (a player's stack is untouched by `TeleportTo`; a summon moved with its owner) kept routing on the old map's mesh. Worse, an instance torn down while empty frees its query, and the same saved instance recreated under the same ids gets a new one, which no cache key can tell apart. The pointers are now looked up again at the top of every `calculate()` (two map lookups per leg), so they can never point at freed memory; the cache key gains map and instance for the plain map change.

No headless trigger for either (an off-mesh link as the sole prefix; a cross-map teleport of a live generator), so verified by construction, compiled from a clean clone, reviewed adversarially (agent pass and a Codex debate, which found the instance-reload case) and the movement suite (S1–S15, S17) passes on a build carrying both. Same code in mangosthree: paired PR.

Paired with mangosthree/server#350.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/269)
<!-- Reviewable:end -->
