### PR TITLE
[Movement] Test a random hop's slope over the distance walked, not per axis

### DIFF
--- a/src/game/WorldHandlers/Map.cpp
+++ b/src/game/WorldHandlers/Map.cpp
@@ -3537,46 +3537,24 @@ bool Map::GetReachableRandomPointOnGround(uint32 phaseMask, float& x, float& y, 
     i_z = *reachable;
 
     // here we have a valid position but the point can have a big Z in some case
-    // next code will check angle from 2 points of view: x-axis and y-axis movement
+    // next code checks the slope of the hop: the rise (a) over the horizontal distance walked (b)
     //        c
     //       /|
     //      / |
     //    b/__|a
 
-    // project vector to get only positive value
-    float ac = fabs(z - i_z);
-    float delta = 0;
-
-    // slope represented by b angle (in radian)
-    float slope = 0;
+    // Testing each axis on its own overstates a diagonal hop by up to sqrt(2) and
+    // rejects it short of the limit; the slope of the hop is over the distance walked.
+    const float ac = fabs(z - i_z);
+    const float horizontal = sqrt((x - i_x) * (x - i_x) + (y - i_y) * (y - i_y));
     const float MAX_SLOPE_IN_RADIAN = 50.0f / 180.0f * M_PI_F;  // 50(degree) max seem best value for walkable slope
 
-    delta = fabs(x - i_x);  // check x-axis movement
-    if (delta > 0.0f)       // check to avoid divide by 0
+    if (horizontal > 0.0f && atan(ac / horizontal) < MAX_SLOPE_IN_RADIAN)
     {
-        // compute slope
-        float slope = atan(ac / delta);
-        if (slope < MAX_SLOPE_IN_RADIAN)
-        {
-            x = i_x;
-            y = i_y;
-            z = i_z;
-            return true;
-        }
-    }
-
-    delta = fabs(y - i_y);  // check y-axis movement
-    if (delta > 0.0f)       // check to avoid divide by 0
-    {
-        // compute slope
-        slope = atan(ac / delta);
-        if (slope < MAX_SLOPE_IN_RADIAN)
-        {
-            x = i_x;
-            y = i_y;
-            z = i_z;
-            return true;
-        }
+        x = i_x;
+        y = i_y;
+        z = i_z;
+        return true;
     }
 
     return false;


### PR DESCRIPTION
`Map::GetReachableRandomPointOnGround` divides the hop's rise by each axis displacement on its own and accepts the hop when either comes under 50°. That overstates a diagonal hop by up to √2: a hop with a true slope of 43° fails both axis tests and the wanderer retries; on a narrow diagonal walkway every candidate can fail. One test, rise over the horizontal distance walked.

The random generator floors every hop through the frame's `GroundPoint` afterwards, so this changes which points are rejected up front, not where a wanderer ends up. Compiled from a clean clone; reviewed adversarially (a Codex debate on the mangosthree side raised the geometry). Paired with the mangosthree PR, which also carries the floor-check sync this core already has.

Paired with mangosthree/server#351.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/270)
<!-- Reviewable:end -->
