### PR TITLE
[Movement] Back off the wander and confused retry after failed attempts

### DIFF
--- a/src/game/MotionGenerators/ConfusedMovementGenerator.cpp
+++ b/src/game/MotionGenerators/ConfusedMovementGenerator.cpp
@@ -28,6 +28,8 @@
 #include "Unit.h"
 #include "Utilities/Util.h"
 
+#include <algorithm>
+
 namespace
 {
     /// How far from the spot it was confused at a unit may stagger.
@@ -97,6 +99,20 @@ void ConfusedMovementGenerator::Finalize(Unit& owner)
     }
 }
 
+uint32 ConfusedMovementGenerator::RetryDelay()
+{
+    // Every failed attempt doubles the wait, up to the shortest normal stagger, so a
+    // spot that never routes is retried a few times a second, not twenty. A lurch
+    // that gets laid resets the count.
+    const uint32 delay = std::min<uint32>(RETRY_DELAY << m_retries, STAGGER_INTERVAL_MIN);
+    if (delay < STAGGER_INTERVAL_MIN)
+    {
+        ++m_retries;
+    }
+
+    return delay;
+}
+
 Motion::MoveIntent ConfusedMovementGenerator::Intent(Unit& owner,
                                                      Motion::MoveStatus const& status,
                                                      uint32 diff)
@@ -112,7 +128,13 @@ Motion::MoveIntent ConfusedMovementGenerator::Intent(Unit& owner,
     if (status.blocked)
     {
         m_haveLurch = false;
-        m_staggerTime.Reset(RETRY_DELAY);
+        m_staggerTime.Reset(RetryDelay());
+    }
+
+    // A lurch that got laid -- seen traveling, or already run out -- ends the failure streak.
+    if (status.arrived || (status.traveling && m_haveLurch))
+    {
+        m_retries = 0;
     }
 
     // The timer runs even mid-leg, which is the point: when it fires early the new
@@ -128,7 +150,7 @@ Motion::MoveIntent ConfusedMovementGenerator::Intent(Unit& owner,
     const auto lurch = Motion::FrameFor(owner).RandomPoint(owner, m_anchor, STAGGER_RADIUS);
     if (!lurch)
     {
-        m_staggerTime.Reset(RETRY_DELAY);
+        m_staggerTime.Reset(RetryDelay());
         return Motion::MoveIntent::Hold();
     }
 

--- a/src/game/MotionGenerators/ConfusedMovementGenerator.h
+++ b/src/game/MotionGenerators/ConfusedMovementGenerator.h
@@ -54,9 +54,13 @@ class ConfusedMovementGenerator final : public IntentMovementGenerator
     private:
         Motion::Vector3 m_anchor;     ///< Where the unit stood when it was confused.
 
+        /// The wait before the next attempt after one that failed; doubles per failure.
+        uint32 RetryDelay();
+
         TimeTracker m_staggerTime{0}; ///< Time left before the next lurch.
         Motion::Vector3 m_lurch;      ///< Where the current lurch is heading.
         bool m_haveLurch = false;     ///< False before the first point has been picked.
+        uint32 m_retries = 0;         ///< Failed attempts in a row; the retry wait doubles with each.
 };
 
 #endif // MANGOS_CONFUSEDMOVEMENTGENERATOR_H

--- a/src/game/MotionGenerators/RandomMovementGenerator.cpp
+++ b/src/game/MotionGenerators/RandomMovementGenerator.cpp
@@ -178,6 +178,21 @@ void RandomMovementGenerator::Finalize(Unit& owner)
     static_cast<Creature&>(owner).SetWalk(!owner.hasUnitState(UNIT_STAT_RUNNING_STATE), false);
 }
 
+uint32 RandomMovementGenerator::RetryDelay()
+{
+    // Every failed attempt doubles the wait, up to the shortest normal rest. A spot that
+    // never routes -- an island, a platform without a mesh, a floor no random point
+    // finds -- is then retried a few times a minute, not twenty times a second for as
+    // long as the creature lives. A hop that gets laid resets the count.
+    const uint32 delay = std::min<uint32>(RETRY_DELAY << m_retries, REST_AFTER_HOP_MIN);
+    if (delay < REST_AFTER_HOP_MIN)
+    {
+        ++m_retries;
+    }
+
+    return delay;
+}
+
 Motion::MoveIntent RandomMovementGenerator::Intent(Unit& owner,
                                                    Motion::MoveStatus const& status,
                                                    uint32 diff)
@@ -203,11 +218,17 @@ Motion::MoveIntent RandomMovementGenerator::Intent(Unit& owner,
     if (status.blocked)
     {
         m_haveHop = false;
-        m_restTime.Reset(RETRY_DELAY);
+        m_restTime.Reset(RetryDelay());
     }
 
     // Mid-hop: re-state the same goal, which the driver recognises as the leg it is
     // already walking and leaves alone.
+    // A hop that got laid -- seen traveling, or already run out -- ends the failure streak.
+    if (status.arrived || (status.traveling && m_haveHop))
+    {
+        m_retries = 0;
+    }
+
     if (status.traveling && m_haveHop)
     {
         return Motion::MoveIntent::Move(m_hop, hopFlags);
@@ -231,7 +252,7 @@ Motion::MoveIntent RandomMovementGenerator::Intent(Unit& owner,
         const auto hop = Motion::FrameFor(owner).RandomPoint(owner, m_centre, m_radius);
         if (!hop)
         {
-            m_restTime.Reset(RETRY_DELAY);
+            m_restTime.Reset(RetryDelay());
             return Motion::MoveIntent::Hold();
         }
 

--- a/src/game/MotionGenerators/RandomMovementGenerator.h
+++ b/src/game/MotionGenerators/RandomMovementGenerator.h
@@ -83,9 +83,13 @@ class RandomMovementGenerator final : public IntentMovementGenerator
         float m_orbitAngle = 0.0f;
         float m_orbitTilt = 0.0f;
 
+        /// The wait before the next attempt after one that failed; doubles per failure.
+        uint32 RetryDelay();
+
         TimeTracker m_restTime{0};   ///< Time left standing before the next hop.
         Motion::Vector3 m_hop;       ///< Where the current hop is heading.
         bool m_haveHop = false;      ///< False before the first point has been picked.
+        uint32 m_retries = 0;        ///< Failed attempts in a row; the retry wait doubles with each.
 };
 
 #endif // MANGOS_RANDOMMOTIONGENERATOR_H


### PR DESCRIPTION
A hop that could not be routed, or a random point that could not be found, was retried after a flat 50 ms, forever (`RETRY_DELAY` in `RandomMovementGenerator` and `ConfusedMovementGenerator`). A creature on a spot that never routes -- an island, a platform without a mesh, a floor no random point finds -- therefore ran a random point and a `PathFinder::calculate` twenty times a second for as long as it lived, and a zone with a few hundred such NPCs paid that permanently.

The wait now doubles with each failed attempt, up to the shortest normal rest (3 s for a wanderer, 0.8 s for a confused one), and resets as soon as a leg is laid and seen traveling. The "no break" case, which deliberately uses the short delay to go straight on to the next hop, is not a failure and is untouched; fliers pick their next point off the orbit and never fail.

No red/green witness headless (nothing observable changes but the CPU spent), so verified by construction: the sequence is 50, 100, 200, 400, 800, 1600, 3000 ms for a wanderer and 50 … 800 ms for a confused unit, then flat. The movement suite (S1–S17, S19) passes on a build carrying this; reviewed adversarially (agent pass and a Codex debate, which raised the case) and compiled from a clean clone. Same code in mangosthree: paired PR.

Paired with mangosthree/server#352.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/272)
<!-- Reviewable:end -->
