### PR TITLE
[Movement] Pause a patrol for a player explicitly; a cut leg resumes

### DIFF
--- a/src/game/BattleGround/BattleGroundHandler.cpp
+++ b/src/game/BattleGround/BattleGroundHandler.cpp
@@ -83,8 +83,8 @@ void WorldSession::HandleBattlemasterHelloOpcode(WorldPacket& recv_data)
         return;
     }
 
-    // Stop the npc if moving
-    pCreature->StopMoving();
+    // Stop the npc if moving; a patrol holds its leg for a while so the player can talk
+    pCreature->HoldForPlayer();
 
     BattleGroundTypeId bgTypeId = sBattleGroundMgr.GetBattleMasterBG(pCreature->GetEntry());
 

--- a/src/game/MotionGenerators/MotionMaster.cpp
+++ b/src/game/MotionGenerators/MotionMaster.cpp
@@ -552,6 +552,17 @@ void MotionMaster::MoveWaypoint(int32 id /*=0*/, uint32 source /*=0==PATH_NO_PAT
     }
 }
 
+bool MotionMaster::PauseWaypoints(int32 ms)
+{
+    if (empty() || top()->GetMovementGeneratorType() != WAYPOINT_MOTION_TYPE)
+    {
+        return false;
+    }
+
+    static_cast<WaypointMovementGenerator*>(top())->Pause(*m_owner, ms);
+    return true;
+}
+
 /**
  * @brief Moves the unit along a taxi flight path.
  * @param path ID of the flight path.

--- a/src/game/MotionGenerators/MotionMaster.h
+++ b/src/game/MotionGenerators/MotionMaster.h
@@ -239,6 +239,13 @@ class MotionMaster : private std::stack<MovementGenerator*>
         void MoveWaypoint(int32 id = 0, uint32 source = 0, uint32 initialDelay = 0, uint32 overwriteEntry = 0);
 
         /**
+         * @brief Holds a waypoint patrol where it stands, for a player to talk to it.
+         * @param ms How long to hold before the patrol goes on; a longer wait already running is kept.
+         * @return True when a waypoint generator was on top and took the pause.
+         */
+        bool PauseWaypoints(int32 ms);
+
+        /**
          * @brief Moves the unit along a taxi flight path.
          * @param path ID of the flight path.
          * @param pathnode Node of the flight path.

--- a/src/game/MotionGenerators/WaypointMovementGenerator.cpp
+++ b/src/game/MotionGenerators/WaypointMovementGenerator.cpp
@@ -210,6 +210,21 @@ void WaypointMovementGenerator::Finalize(Unit& owner)
     static_cast<Creature&>(owner).SetWalk(!owner.hasUnitState(UNIT_STAT_RUNNING_STATE), false);
 }
 
+void WaypointMovementGenerator::Pause(Unit& owner, int32 ms)
+{
+    // The one pause there is. Whatever leg was in flight is dropped; Intent prepares a
+    // fresh one, toward the same node, once the time is up. A wait already running --
+    // a node's delay, the initial delay -- is left alone, as it always was.
+    owner.StopMoving();
+    ClearSegment();
+    m_haveLeg = false;
+
+    if (m_nextMoveTime.Passed())
+    {
+        Stop(ms);
+    }
+}
+
 bool WaypointMovementGenerator::Stopped(Unit const& owner) const
 {
     return !m_nextMoveTime.Passed() || owner.hasUnitState(UNIT_STAT_WAYPOINT_PAUSED);
@@ -554,10 +569,27 @@ Motion::MoveIntent WaypointMovementGenerator::Intent(Unit& owner,
                                                      Motion::MoveStatus const& status,
                                                      uint32 diff)
 {
+    // A leg cut short from outside -- a stun, a root, a script's StopMoving -- is neither
+    // an arrival nor a pause; the pause comes only from Pause(). Forget the leg here,
+    // before any hold below can swallow the edge, so the first free tick prepares a
+    // fresh one from where the unit stands, toward the same node.
+    if (status.cut)
+    {
+        ClearSegment();
+        m_haveLeg = false;
+    }
+
     // Waypoint movement can be switched off -- handy for escort quests and the like.
     if (owner.hasUnitState(UNIT_STAT_NOT_MOVE) || !m_path || m_path->empty())
     {
         owner.clearUnitState(UNIT_STAT_ROAMING_MOVE);
+        return Motion::MoveIntent::Hold();
+    }
+
+    // A cast with a cast time holds the patrol where the AI stopped it for the cast; the
+    // leg is prepared afresh once the cast is over.
+    if (owner.IsNonMeleeSpellCasted(false, false, true))
+    {
         return Motion::MoveIntent::Hold();
     }
 
@@ -590,10 +622,7 @@ Motion::MoveIntent WaypointMovementGenerator::Intent(Unit& owner,
     }
 
     // Nothing is in flight and nothing was laid: this is the first tick after Initialize or
-    // Reset (the driver lays the first leg on the first TICK, not in Initialize). The
-    // force-stop test below would read a creature that has simply not started yet as one a
-    // player just halted, and park it for STOP_TIME_FOR_PLAYER -- three minutes of standing
-    // still at every spawn and after every evade.
+    // Reset (the driver lays the first leg on the first TICK, not in Initialize).
     if (!m_haveLeg && !status.traveling)
     {
         return PrepareMove(creature);
@@ -611,18 +640,9 @@ Motion::MoveIntent WaypointMovementGenerator::Intent(Unit& owner,
     // as reached as it gets. Arrive there, so its script, delay and inform still run.
     const bool asCloseAsItGets = status.blocked && m_approached;
 
-    // Sample the stopped state BEFORE arrival handling clears UNIT_STAT_ROAMING_MOVE, so an
-    // externally force-stopped unit (a player talking to it, which also finalizes the
-    // spline) is paused rather than mistaken for a leg that simply finished.
     switch (asCloseAsItGets ? WaypointSegmentUpdateState::Finalized
-                            : GetWaypointSegmentUpdateState(!status.traveling, creature.IsStopped()))
+                            : GetWaypointSegmentUpdateState(!status.traveling))
     {
-        case WaypointSegmentUpdateState::Stopped:
-            ClearSegment();
-            m_haveLeg = false;
-            Stop(STOP_TIME_FOR_PLAYER);
-            return Motion::MoveIntent::Hold();
-
         case WaypointSegmentUpdateState::Finalized:
             ProcessSegmentProgress(creature, status.pathIndex);
             if (!m_isArrivalDone)

--- a/src/game/MotionGenerators/WaypointMovementGenerator.h
+++ b/src/game/MotionGenerators/WaypointMovementGenerator.h
@@ -107,6 +107,10 @@ class WaypointMovementGenerator final : public IntentMovementGenerator
         void Interrupt(Unit& owner) override;
         void Reset(Unit& owner) override;
 
+        /// Hold the patrol where it stands for a while (a player talking to it); the leg
+        /// is prepared afresh, toward the same node, when the time is up.
+        void Pause(Unit& owner, int32 ms);
+
         MovementGeneratorType GetMovementGeneratorType() const override { return WAYPOINT_MOTION_TYPE; }
 
         bool GetResetPosition(Unit& owner, float& x, float& y, float& z, float& o) const override;

--- a/src/game/MotionGenerators/WaypointSmoothing.cpp
+++ b/src/game/MotionGenerators/WaypointSmoothing.cpp
@@ -32,22 +32,14 @@ bool HasReachedWaypointEndpoint(int32 currentPathIdx, size_t endpointPathIndex)
 }
 
 /**
- * @brief Classifies an in-progress segment, giving a force-stop precedence over a finished spline.
+ * @brief Classifies an in-progress segment by whether its spline has completed.
  * @param splineFinalized Whether the spline has completed.
- * @param creatureStopped Whether the unit is stopped (sampled before arrival handling).
  * @return The resulting WaypointSegmentUpdateState.
  */
-WaypointSegmentUpdateState GetWaypointSegmentUpdateState(bool splineFinalized, bool creatureStopped)
+WaypointSegmentUpdateState GetWaypointSegmentUpdateState(bool splineFinalized)
 {
-    // A force-stop (talking to the NPC, root, etc.) clears UNIT_STAT_MOVING and also
-    // finalizes the spline, so the stopped state must win or the unit would relaunch
-    // instead of pausing. The caller samples it before arrival handling clears
-    // UNIT_STAT_ROAMING_MOVE, else a normally finishing spline would look stopped too.
-    if (creatureStopped)
-    {
-        return WaypointSegmentUpdateState::Stopped;
-    }
-
+    // A stop from outside is not read here any more: the driver reports it as a cut
+    // leg, and the waypoint generator pauses or resumes on its own terms.
     if (splineFinalized)
     {
         return WaypointSegmentUpdateState::Finalized;

--- a/src/game/MotionGenerators/WaypointSmoothing.h
+++ b/src/game/MotionGenerators/WaypointSmoothing.h
@@ -53,7 +53,6 @@ struct WaypointSmoothingNode
 enum class WaypointSegmentUpdateState
 {
     Moving,   ///< Spline still running normally
-    Stopped,  ///< Unit force-stopped while the spline is unfinished
     Finalized ///< Spline has completed
 };
 
@@ -90,12 +89,11 @@ bool IsWaypointSmoothingSafe(WaypointSmoothingNode const& node);
 bool HasReachedWaypointEndpoint(int32 currentPathIdx, size_t endpointPathIndex);
 
 /**
- * @brief Classifies an in-progress segment, giving finalized precedence over stopped.
+ * @brief Classifies an in-progress segment by whether its spline has completed.
  * @param splineFinalized Whether the spline has completed.
- * @param creatureStopped Whether the unit is currently stopped.
  * @return The resulting WaypointSegmentUpdateState.
  */
-WaypointSegmentUpdateState GetWaypointSegmentUpdateState(bool splineFinalized, bool creatureStopped);
+WaypointSegmentUpdateState GetWaypointSegmentUpdateState(bool splineFinalized);
 
 /**
  * @brief Expands the bounding box to include the given point.

--- a/src/game/Object/Creature.h
+++ b/src/game/Object/Creature.h
@@ -645,6 +645,8 @@ class Creature : public Unit
         CreatureAI* AI() { return i_AI; }
 
         void SetWalk(bool enable, bool asDefault = true);
+        /// Stop where it stands and, for a patrol, hold the leg a while so the player can talk.
+        void HoldForPlayer();
         void SetLevitate(bool enable) override;
         void SetSwim(bool enable) override;
         void SetCanFly(bool enable) override;

--- a/src/game/Object/CreatureMovement.cpp
+++ b/src/game/Object/CreatureMovement.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "Creature.h"
+#include "WaypointMovementGenerator.h"
 #include "WorldPacket.h"
 #include "Opcodes.h"
 
@@ -38,6 +39,14 @@
  * @param enable true to walk; false to run.
  * @param asDefault true to also update the default running state.
  */
+void Creature::HoldForPlayer()
+{
+    StopMoving();
+    // The pause is asked for by name: nothing infers it from the stop any more, so a
+    // stun or a script's StopMoving() no longer parks a patrol for minutes.
+    GetMotionMaster()->PauseWaypoints(STOP_TIME_FOR_PLAYER);
+}
+
 void Creature::SetWalk(bool enable, bool asDefault)
 {
     if (asDefault)

--- a/src/game/WorldHandlers/ItemHandlerVendor.cpp
+++ b/src/game/WorldHandlers/ItemHandlerVendor.cpp
@@ -302,8 +302,8 @@ void WorldSession::SendListInventory(ObjectGuid vendorguid)
         GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
     }
 
-    // Stop the npc if moving
-    pCreature->StopMoving();
+    // Stop the npc if moving; a patrol holds its leg for a while so the player can talk
+    pCreature->HoldForPlayer();
 
     VendorItemData const* vItems = pCreature->GetVendorItems();
     VendorItemData const* tItems = pCreature->GetVendorTemplateItems();

--- a/src/game/WorldHandlers/NPCHandler.cpp
+++ b/src/game/WorldHandlers/NPCHandler.cpp
@@ -457,7 +457,7 @@ void WorldSession::HandleGossipHelloOpcode(WorldPacket& recv_data)
         GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
     }
 
-    pCreature->StopMoving();
+    pCreature->HoldForPlayer();
 
     if (pCreature->IsSpiritGuide())
     {

--- a/src/game/WorldHandlers/QuestHandler.cpp
+++ b/src/game/WorldHandlers/QuestHandler.cpp
@@ -138,8 +138,8 @@ void WorldSession::HandleQuestgiverHelloOpcode(WorldPacket& recv_data)
         GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
     }
 
-    // Stop the npc if moving
-    pCreature->StopMoving();
+    // Stop the npc if moving; a patrol holds its leg for a while so the player can talk
+    pCreature->HoldForPlayer();
 
     if (sScriptMgr.OnGossipHello(_player, pCreature))
     {


### PR DESCRIPTION
The waypoint generator inferred "a player stopped me" from `IsStopped()`, which every `StopMoving()` sets, and parked the patrol for `STOP_TIME_FOR_PLAYER` (three minutes). A stun or a root on a patrolling creature outside combat, or a script's `StopMoving()`, therefore froze it for three minutes after the control wore off, and `Reset()` never cleared the timer. (In combat a chase sits on top while the control lasts, so the common case never showed it.)

Two changes. The pause is asked for by name: `Creature::HoldForPlayer()` (stop, then `MotionMaster::PauseWaypoints`, taken by a waypoint generator on top) replaces the bare `StopMoving()` in the gossip, quest-giver, vendor and battlemaster handlers; a wait already running at a node is left alone, as it always was. And the generator treats a leg the driver reports as *cut* for what it is: neither an arrival nor a pause. The cut edge is latched at the top of `Intent`, before any hold can swallow it, so the first free tick prepares a fresh leg from where the unit stands toward the same node; a cast with a cast time holds it until the cast ends (the AI stops the creature for that), and a node already passed inside a smoothed segment is not informed again. The segment-state helper loses its stopped input, which had no other reader. Scripted pauses (`UNIT_STAT_WAYPOINT_PAUSED`) are unchanged. One deliberate consequence: a script's bare `StopMoving()` on a patrolling creature no longer parks it for three minutes (no SD3 script relied on that; the ones that stop a patrol switch generators).

Stacked on #268 (uses the `cut` outcome); its commits drop out on rebase.

Verified headless on the live 4.3.4 build, red on the old code and green here: a patrolling creature stunned mid-leg by a self-cast (no combat) stood at the stun spot for the whole 30-s window before; now it moves on within a tick and reaches its next node (S19). The rest of the suite passes; reviewed adversarially (agent pass and a Codex debate, which caught the three sibling handlers and the cast case) and compiled from a clean clone. Same code in mangosthree: paired PR.

Paired with mangosthree/server#353.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/273)
<!-- Reviewable:end -->
