### PR TITLE
Draw the zone map's vehicles and landmarks

### DIFF
--- a/src/game/ChatCommands/DebugCommands.cpp
+++ b/src/game/ChatCommands/DebugCommands.cpp
@@ -59,6 +59,9 @@
 #include "MapManager.h"
 #include "TransportMap.h"
 #include "Transports.h"
+#include "WorldStateMgr.h"
+#include "DBCStores.h"
+#include "DBCStructure.h"
 
 /**
  * @brief Handler for HandleDebugSendSpellFailCommand command.
@@ -445,6 +448,108 @@ bool ChatHandler::HandleDebugUpdateWorldStateCommand(char* args)
     }
 
     m_session->GetPlayer()->SendUpdateWorldState(world, state);
+    return true;
+}
+
+/**
+ * @brief Handler for HandleDebugWorldStateCommand command.
+ *
+ * `.debug worldstate <stateId> [value]` -- read or set a STORED world state for the zone
+ * the caller is standing in, and push the change to everyone else standing in it. The
+ * difference from `.debug uws` is the whole point: that one fires a packet at the caller
+ * and forgets it, so the value is gone the moment anything re-sends the zone's init set.
+ * This one is what the client will be told again on every zone entry.
+ *
+ * @param args Command arguments.
+ * @returns True if the command executed successfully, false otherwise.
+ */
+bool ChatHandler::HandleDebugWorldStateCommand(char* args)
+{
+    uint32 stateId;
+    if (!ExtractUInt32(&args, stateId))
+    {
+        return false;
+    }
+
+    Player* player = m_session->GetPlayer();
+    const uint32 zoneId = player->GetCachedZoneId();
+
+    uint32 value;
+    if (!ExtractUInt32(&args, value))
+    {
+        PSendSysMessage("World state %u in zone %u = %u",
+                        stateId, zoneId, sWorldStateMgr.GetState(zoneId, stateId));
+        return true;
+    }
+
+    const bool changed = sWorldStateMgr.SetState(zoneId, stateId, value);
+    PSendSysMessage("World state %u in zone %u -> %u%s", stateId, zoneId, value,
+                    changed ? "" : " (unchanged, nothing sent)");
+
+    // What it drives, if anything -- the reason to be setting one by hand at all.
+    for (AreaPOIEntry const* poi : sWorldStateMgr.PoisOfState(stateId))
+    {
+        PSendSysMessage("  landmark %u (area %u): icon %u",
+                        poi->ID, poi->AreaID,
+                        value >= 1 && value <= 9 ? poi->Icon[value - 1] : 0);
+    }
+
+    return true;
+}
+
+/**
+ * @brief Handler for HandleDebugPoiCommand command.
+ *
+ * `.debug poi` lists the map landmarks of the caller's zone that the server can move,
+ * with the world state each one reads and its current value. `.debug poi <id> <value>`
+ * moves one: 0 takes it off the map, 1..9 picks Icon[value - 1] from its own row.
+ *
+ * @param args Command arguments.
+ * @returns True if the command executed successfully, false otherwise.
+ */
+bool ChatHandler::HandleDebugPoiCommand(char* args)
+{
+    Player* player = m_session->GetPlayer();
+    const uint32 zoneId = player->GetCachedZoneId();
+
+    uint32 poiId;
+    if (!ExtractUInt32(&args, poiId))
+    {
+        std::vector<AreaPOIEntry const*> pois = sWorldStateMgr.PoisOfZone(zoneId);
+        if (pois.empty())
+        {
+            PSendSysMessage("Zone %u has no world-state-driven map landmark.", zoneId);
+            return true;
+        }
+
+        PSendSysMessage("Zone %u, %u landmark(s):", zoneId, uint32(pois.size()));
+        for (AreaPOIEntry const* poi : pois)
+        {
+            PSendSysMessage("  poi %u  state %u = %u  area %u  \"%s\"",
+                            poi->ID, poi->WorldStateID,
+                            sWorldStateMgr.GetState(zoneId, poi->WorldStateID),
+                            poi->AreaID,
+                            poi->Name_lang[GetSessionDbcLocale()] ?
+                                poi->Name_lang[GetSessionDbcLocale()] : "");
+        }
+
+        return true;
+    }
+
+    uint32 value;
+    if (!ExtractUInt32(&args, value))
+    {
+        return false;
+    }
+
+    if (!sWorldStateMgr.SetPoiState(poiId, value))
+    {
+        PSendSysMessage("Landmark %u is unknown, or reads no world state.", poiId);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    PSendSysMessage("Landmark %u -> %u", poiId, value);
     return true;
 }
 

--- a/src/game/Object/Creature.cpp
+++ b/src/game/Object/Creature.cpp
@@ -280,6 +280,17 @@ void Creature::AddToWorld()
         hull->EnlistCrew(this);
     }
 
+    // AND THE ZONE MAP, if this one is drawn on it. Announced the way a vessel is --
+    // to everyone on the anchor map at once -- because the client builds its map-icon
+    // list from CREATE blocks alone. Waiting for each player's visibility sweep would
+    // mean the icon showing up only once he is close enough to see the vehicle without
+    // it, which is the wrong way round.
+    if (IsTrackedOnZoneMap())
+    {
+        GetMap()->RegisterZoneMapTracked(this);
+        GetMap()->AnnounceZoneMapTracked(this);
+    }
+
     // Make active if required
     if (sWorld.isForceLoadMap(GetMapId()) ||
         (GetCreatureInfo()->ExtraFlags & CREATURE_FLAG_EXTRA_ACTIVE) ||
@@ -325,6 +336,10 @@ void Creature::RemoveFromWorld()
         {
             hull->DelistCrew(this);
         }
+
+        // Off the icon list. No destroy block goes with it -- see
+        // Object::BuildOutOfRangeUpdateBlock -- this only stops it being announced again.
+        GetMap()->UnregisterZoneMapTracked(this);
     }
 
     ///- Remove the creature from the accessor

--- a/src/game/Object/ObjectUpdate.cpp
+++ b/src/game/Object/ObjectUpdate.cpp
@@ -229,9 +229,26 @@ void Object::BuildValuesUpdateBlockForPlayer(UpdateData* data, Player* target) c
  *
  * Adds this object's GUID to the out-of-range list,
  * indicating it should be removed from the client's view.
+ *
+ * A UNIT THE CLIENT DRAWS ON THE ZONE MAP IS NEVER SENT ONE. The battlefield-vehicle
+ * list is built on CREATE and emptied on DESTROY, and a destroy block is a destroy
+ * block whatever prompted it -- so the moment an observer ashore drifts out of the
+ * vessel's relay range, or a deck is torn down for him, the gunship drops out of that
+ * list and its icon disappears from his map. The icon is meant to hold for the whole
+ * zone, far past anything the observer can see, so the block is refused at the one
+ * place every caller goes through rather than at each of them.
+ *
+ * The leak this trades for is bounded and harmless: the client dedups the list by guid,
+ * caps it at 40, and clears it outright on world init -- and Blizzard ships exactly two
+ * rows carrying the flag.
  */
 void Object::BuildOutOfRangeUpdateBlock(UpdateData* data) const
 {
+    if (isType(TYPEMASK_UNIT) && ((Unit const*)this)->IsTrackedOnZoneMap())
+    {
+        return;
+    }
+
     data->AddOutOfRangeGUID(GetObjectGuid());
 }
 
@@ -241,10 +258,24 @@ void Object::BuildOutOfRangeUpdateBlock(UpdateData* data) const
  *
  * Sends a destroy packet to the specified player,
  * removing this object from their game world.
+ *
+ * Refused for a unit the client tracks on the zone map, for the reason spelled out over
+ * BuildOutOfRangeUpdateBlock: this is the other door out, and the visibility sweep uses
+ * THIS one for creatures. Guarding only the update block would have left the hole open.
+ *
+ * The cost is that such a unit really removed at runtime keeps its icon until the client
+ * next clears the list -- a zone change or a relog. That is the right way round: an icon
+ * that lingers is a nuisance, an icon that vanishes whenever the player walks inland is
+ * the bug being fixed.
  */
 void Object::DestroyForPlayer(Player* target, bool anim) const
 {
     MANGOS_ASSERT(target);
+
+    if (isType(TYPEMASK_UNIT) && ((Unit const*)this)->IsTrackedOnZoneMap())
+    {
+        return;
+    }
 
     WorldPacket data(SMSG_DESTROY_OBJECT, 9);
     data << GetObjectGuid();
@@ -377,6 +408,11 @@ void Object::BuildMovementUpdate(ByteBuffer* data, uint16 updateFlags) const
         }
     }
 
+    // WHAT the tail carries is resolved here; the ORDER it goes out in is not ours to
+    // decide twice. It is a non-numeric queue the 3.3.5a client hard-codes, and it lives
+    // in UpdateBlock::WriteMovementTail with a test pinning its bytes.
+    UpdateBlock::MovementTail tail;
+
     // 0x8
     if (updateFlags & UPDATEFLAG_LOWGUID)
     {
@@ -388,23 +424,18 @@ void Object::BuildMovementUpdate(ByteBuffer* data, uint16 updateFlags) const
             case TYPEID_GAMEOBJECT:
             case TYPEID_DYNAMICOBJECT:
             case TYPEID_CORPSE:
-                *data << uint32(GetGUIDLow());              // GetGUIDLow()
+                tail.lowGuid = GetGUIDLow();
                 break;
             case TYPEID_UNIT:
-                *data << uint32(0x0000000B);                // unk, can be 0xB or 0xC
+                tail.lowGuid = 0x0000000B;                  // unk, can be 0xB or 0xC
                 break;
             case TYPEID_PLAYER:
-                if (updateFlags & UPDATEFLAG_SELF)
-                {
-                    *data << uint32(0x0000002F);            // unk, can be 0x15 or 0x22
-                }
-                else
-                {
-                    *data << uint32(0x00000008);            // unk, can be 0x7 or 0x8
-                }
+                tail.lowGuid = (updateFlags & UPDATEFLAG_SELF) ?
+                    0x0000002F :                            // unk, can be 0x15 or 0x22
+                    0x00000008;                             // unk, can be 0x7 or 0x8
                 break;
             default:
-                *data << uint32(0x00000000);                // unk
+                tail.lowGuid = 0x00000000;                  // unk
                 break;
         }
     }
@@ -420,37 +451,28 @@ void Object::BuildMovementUpdate(ByteBuffer* data, uint16 updateFlags) const
             case TYPEID_GAMEOBJECT:
             case TYPEID_DYNAMICOBJECT:
             case TYPEID_CORPSE:
-                *data << uint32(GetObjectGuid().GetHigh()); // GetGUIDHigh()
+                tail.highGuid = GetObjectGuid().GetHigh();
                 break;
             case TYPEID_UNIT:
-                *data << uint32(0x0000000B);                // unk, can be 0xB or 0xC
+                tail.highGuid = 0x0000000B;                 // unk, can be 0xB or 0xC
                 break;
             case TYPEID_PLAYER:
-                if (updateFlags & UPDATEFLAG_SELF)
-                {
-                    *data << uint32(0x0000002F);            // unk, can be 0x15 or 0x22
-                }
-                else
-                {
-                    *data << uint32(0x00000008);            // unk, can be 0x7 or 0x8
-                }
+                tail.highGuid = (updateFlags & UPDATEFLAG_SELF) ?
+                    0x0000002F :                            // unk, can be 0x15 or 0x22
+                    0x00000008;                             // unk, can be 0x7 or 0x8
                 break;
             default:
-                *data << uint32(0x00000000);                // unk
+                tail.highGuid = 0x00000000;                 // unk
                 break;
         }
     }
 
-    // 0x4
-    if (updateFlags & UPDATEFLAG_HAS_ATTACKING_TARGET)      // packed guid (current target guid)
+    // 0x4 -- packed guid (current target guid)
+    if (updateFlags & UPDATEFLAG_HAS_ATTACKING_TARGET)
     {
-        if (((Unit*)this)->getVictim())
+        if (Unit* victim = ((Unit*)this)->getVictim())
         {
-            *data << ((Unit*)this)->getVictim()->GetPackGUID();
-        }
-        else
-        {
-            data->appendPackGUID(0);
+            tail.attackingTarget = victim->GetObjectGuid().GetRawValue();
         }
     }
 
@@ -465,26 +487,28 @@ void Object::BuildMovementUpdate(ByteBuffer* data, uint16 updateFlags) const
         if (isType(TYPEMASK_GAMEOBJECT)
             && ((GameObject*)this)->GetGoType() == GAMEOBJECT_TYPE_MO_TRANSPORT)
         {
-            *data << uint32(((Transport*)this)->GetPathProgress());
+            tail.transportTime = ((Transport*)this)->GetPathProgress();
         }
         else
         {
-            *data << uint32(GameTime::GetGameTimeMS());       // ms time
+            tail.transportTime = GameTime::GetGameTimeMS();  // ms time
         }
     }
 
-    // 0x80
+    // 0x80 -- the Vehicle.dbc row, and the facing the client rotates the map icon by.
     if (updateFlags & UPDATEFLAG_VEHICLE)
     {
-        *data << uint32(((Unit*)this)->GetVehicleInfo()->GetVehicleEntry()->ID); // vehicle id
-        *data << float(((WorldObject*)this)->Where().Facing());
+        tail.vehicleId = ((Unit*)this)->GetVehicleInfo()->GetVehicleEntry()->ID;
+        tail.vehicleFacing = ((WorldObject*)this)->Where().Facing();
     }
 
     // 0x200
     if (updateFlags & UPDATEFLAG_ROTATION)
     {
-        *data << int64(((GameObject*)this)->GetPackedRotation());
+        tail.rotation = ((GameObject*)this)->GetPackedRotation();
     }
+
+    UpdateBlock::WriteMovementTail(*data, updateFlags, tail);
 }
 
 /**

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -70,6 +70,7 @@
 #include "BattleGround/BattleGroundMgr.h"
 #include "BattleGround/BattleGroundAV.h"
 #include "OutdoorPvP/OutdoorPvP.h"
+#include "WorldStateMgr.h"
 #include "ArenaTeam.h"
 #include "Chat.h"
 #include "Spell.h"
@@ -3775,6 +3776,12 @@ void Player::SendInitWorldStates(uint32 zoneid, uint32 areaid)
             }
             break;
     }
+
+    // The durable ones, last: a map landmark is drawn from a world state whose owner is
+    // no battleground and no script instance, so nobody would be asked for it here. A zone
+    // override is meant to win over a global default, and the client keeps what it was told
+    // last -- which is why this goes after the fixed set above rather than before it.
+    sWorldStateMgr.FillInitialStates(zoneid, data, count);
 
     FillBGWeekendWorldStates(data, count);
 

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -6792,6 +6792,18 @@ void Unit::SetVehicleId(uint32 entry, uint32 overwriteNpcEntry)
     }
 }
 
+bool Unit::IsTrackedOnZoneMap() const
+{
+    if (!m_vehicleInfo)
+    {
+        return false;
+    }
+
+    VehicleEntry const* ventry = m_vehicleInfo->GetVehicleEntry();
+
+    return ventry && (ventry->Flags & VEHICLE_FLAG_ZONE_MAP_ICON) != 0;
+}
+
 /**
  * @brief Advances active spline movement and updates world position.
  *

--- a/src/game/Object/Unit.h
+++ b/src/game/Object/Unit.h
@@ -2087,8 +2087,21 @@ uint32  GetPower(Powers power) const { return GetUInt32Value(UNIT_FIELD_POWER1 +
         void Unmount(bool from_aura = false);
 
         VehicleInfo* GetVehicleInfo() { return m_vehicleInfo; }
+        VehicleInfo const* GetVehicleInfo() const { return m_vehicleInfo; }
         bool IsVehicle() const { return m_vehicleInfo != NULL; }
         void SetVehicleId(uint32 entry, uint32 overwriteNpcEntry);
+
+        /**
+         * @brief Whether the client draws this unit as a moving icon on the zone map.
+         *
+         * True when the unit's Vehicle.dbc row carries VEHICLE_FLAG_ZONE_MAP_ICON. Such a
+         * unit is entered into the client's battlefield-vehicle list on CREATE and taken
+         * out of it on DESTROY -- range never enters into it, on either side. So it must
+         * never be sent an out-of-range block: the icon is meant to be visible across the
+         * whole zone, and a destroy sent because the observer walked away takes the ship
+         * off the map for him until he happens to see the hull again.
+         */
+        bool IsTrackedOnZoneMap() const;
 
         /**
          * Returns the maximum skill value the given Unit can have. Ie: the sword skill can

--- a/src/game/Object/Vehicle.cpp
+++ b/src/game/Object/Vehicle.cpp
@@ -547,10 +547,13 @@ void VehicleInfo::UnBoard(Unit* passenger, bool changeVehicle)
     // Some creature vehicles get despawned after passenger unboarding
     if (m_owner->GetTypeId() == TYPEID_UNIT)
     {
-        // TODO: Guesswork, but seems to be fairly near correct
+        // TODO: Guesswork, kept as-is only because nothing has re-derived it. The second
+        // bit tested here is the ZONE-MAP ICON gate, which in the client has nothing to do
+        // with despawning -- it happens to be set on the siege vehicles this rule was
+        // observed on, so the behaviour and the flag agree by coincidence, not by meaning.
         // Only if the passenger was on control seat? Also depending on some flags
         if ((seatEntry->Flags & SEAT_FLAG_CAN_CONTROL) &&
-                !(m_vehicleEntry->Flags & (VEHICLE_FLAG_UNK4 | VEHICLE_FLAG_UNK20)))
+                !(m_vehicleEntry->Flags & (VEHICLE_FLAG_UNK4 | VEHICLE_FLAG_ZONE_MAP_ICON)))
         {
             if (((Creature*)m_owner)->IsTemporarySummon())
             {

--- a/src/game/Object/WorldObjectSummon.cpp
+++ b/src/game/Object/WorldObjectSummon.cpp
@@ -62,6 +62,7 @@
 #include "CreatureLinkingMgr.h"
 #include "Chat.h"
 #include "GameTime.h"
+#include "TransportMap.h"
 #ifdef ENABLE_ELUNA
 #include "LuaEngine.h"
 #include "ElunaConfig.h"
@@ -745,6 +746,21 @@ void WorldObject::BuildUpdateData(UpdateDataMapType& update_players)
 {
     WorldObjectChangeAccumulator notifier(*this, update_players);
     Cell::VisitWorldObjects(this, notifier, GetMap()->GetBroadcastRadius());
+
+    // ACROSS A VESSEL'S BOUNDARY. The visit above walks cells on this object's own map, and
+    // a deck and the shore it sails past are two maps -- so on that route a value change
+    // never crosses, in either direction. No HaveAtClient test here on purpose: the people
+    // on the far side hold this object through the vessel's map-membership channel, which
+    // deliberately leaves no mark in the set that test reads.
+    std::vector<Player*> across;
+    TransportMap::CollectRelayAudience(this, across);
+    for (Player* observer : across)
+    {
+        if (observer != this && observer->IsInWorld())
+        {
+            BuildUpdateDataForPlayer(observer, update_players);
+        }
+    }
 
     ClearUpdateMask(false);
 }

--- a/src/game/Server/DBCEnums.h
+++ b/src/game/Server/DBCEnums.h
@@ -505,7 +505,14 @@ enum VehicleFlags
     VEHICLE_FLAG_UNK17              = 0x02000000,
     VEHICLE_FLAG_UNK18              = 0x04000000,
     VEHICLE_FLAG_UNK19              = 0x08000000,
-    VEHICLE_FLAG_UNK20              = 0x10000000,           // Vehicle not dismissed after eject passenger?
+    // THE ZONE-MAP ICON, and nothing else on this path. The client tests exactly this bit
+    // on the unit CREATE path, and a unit that carries it is appended to the battlefield
+    // vehicle list Lua_GetNumBattlefieldVehicles reads -- which is what draws the moving
+    // icon on the zone map. The icon itself comes from UiLocomotionType, not from here.
+    // Emulators have long carried this as "Vehicle not dismissed after eject passenger?",
+    // question mark included. That reading is a guess and it is wrong; it survives below
+    // only as behaviour nobody has re-derived, not as a meaning of the bit.
+    VEHICLE_FLAG_ZONE_MAP_ICON      = 0x10000000,
     VEHICLE_FLAG_UNK21              = 0x20000000,
     VEHICLE_FLAG_UNK22              = 0x40000000,
     VEHICLE_FLAG_UNK23              = 0x80000000,

--- a/src/game/Server/DBCStores.cpp
+++ b/src/game/Server/DBCStores.cpp
@@ -71,6 +71,7 @@ typedef std::map<WMOAreaTableTripple, WMOAreaTableEntry const*> WMOAreaInfoByTri
 
 DBCStorage <AreaTableEntry> sAreaStore(AreaTableEntryfmt);
 DBCStorage <AreaGroupEntry> sAreaGroupStore(AreaGroupEntryfmt);
+DBCStorage <AreaPOIEntry> sAreaPOIStore(AreaPOIEntryfmt);
 static AreaFlagByAreaID sAreaFlagByAreaID;
 static AreaFlagByMapID  sAreaFlagByMapID;                   // for instances without generated *.map files
 
@@ -446,7 +447,7 @@ void LoadDBCStores(const std::string& dataPath)
         exit(1);
     }
 
-    const uint32 DBCFilesCount = 99;
+    const uint32 DBCFilesCount = 100;
 
     BarGoLink bar(DBCFilesCount);
 
@@ -478,6 +479,7 @@ void LoadDBCStores(const std::string& dataPath)
     LoadDBC(availableDbcLocales, bar, bad_dbc_files, sAchievementCategoryStore, dbcPath, "Achievement_Category.dbc");
     LoadDBC(availableDbcLocales, bar, bad_dbc_files, sAreaTriggerStore,         dbcPath, "AreaTrigger.dbc");
     LoadDBC(availableDbcLocales, bar, bad_dbc_files, sAreaGroupStore,           dbcPath, "AreaGroup.dbc");
+    LoadDBC(availableDbcLocales, bar, bad_dbc_files, sAreaPOIStore,             dbcPath, "AreaPOI.dbc");
     LoadDBC(availableDbcLocales, bar, bad_dbc_files, sAuctionHouseStore,        dbcPath, "AuctionHouse.dbc");
     LoadDBC(availableDbcLocales, bar, bad_dbc_files, sBankBagSlotPricesStore,   dbcPath, "BankBagSlotPrices.dbc");
     LoadDBC(availableDbcLocales, bar, bad_dbc_files, sBattlemasterListStore,    dbcPath, "BattlemasterList.dbc");

--- a/src/game/Server/DBCStores.h
+++ b/src/game/Server/DBCStores.h
@@ -170,6 +170,7 @@ extern DBCStorage <AchievementCriteriaEntry>     sAchievementCriteriaStore;
 extern DBCStorage <AchievementCategoryEntry>     sAchievementCategoryStore;
 extern DBCStorage <AreaTableEntry>               sAreaStore;// recommend access using functions
 extern DBCStorage <AreaGroupEntry>               sAreaGroupStore;
+extern DBCStorage <AreaPOIEntry>                 sAreaPOIStore;
 extern DBCStorage <AreaTriggerEntry>             sAreaTriggerStore;
 extern DBCStorage <AuctionHouseEntry>            sAuctionHouseStore;
 extern DBCStorage <BankBagSlotPricesEntry>       sBankBagSlotPricesStore;

--- a/src/game/Server/DBCStructure.h
+++ b/src/game/Server/DBCStructure.h
@@ -546,6 +546,33 @@ struct AreaGroupEntry
 };
 
 /**
+* \struct AreaPOIEntry
+* \brief One map landmark -- the fixed points the client draws on a zone or continent map.
+*
+* The client rebuilds its landmark list from this table alone (GetNumMapLandmarks /
+* GetMapLandmarkInfo). A row with WorldStateID == 0 is drawn unconditionally; a row that
+* names one is drawn ONLY while that world state's value is non-zero, and the icon it
+* draws is Icon[value - 1], clamped to 0..8. That is the whole of mechanism B: the server
+* moves a number, the client moves an icon. See WorldStateMgr.
+*/
+struct AreaPOIEntry
+{
+    uint32  ID;                                             // 0        m_ID
+    int32   Importance;                                     // 1        m_importance
+    uint32  Icon[9];                                        // 2-10     m_icon -- selected by world state value minus one
+    uint32  FactionID;                                      // 11       m_factionID
+    float   Pos[3];                                         // 12-14    m_x, m_y, m_z
+    uint32  ContinentID;                                    // 15       m_continentID
+    uint32  Flags;                                          // 16       m_flags
+    uint32  AreaID;                                         // 17       m_areaID
+    char*   Name_lang[16];                                  // 18-33    m_name_lang
+    // 34       m_name_lang string flags
+    // 35-51    m_description_lang (+ string flags), not loaded
+    uint32  WorldStateID;                                   // 52       m_worldStateID -- 0 = always drawn
+    uint32  WorldMapLink;                                   // 53       m_worldMapLink
+};
+
+/**
 * \struct AreaTriggerEntry
 * \brief Entry representing an area which need to send a specific trigger for quest/resting/..
 */

--- a/src/game/Server/DBCStructure_reference.h
+++ b/src/game/Server/DBCStructure_reference.h
@@ -16,7 +16,7 @@
  *   Achievement_Criteria           ACTIVE
  *   AnimationData                  DOC   (8 cols)
  *   AreaGroup                      ACTIVE
- *   AreaPOI                        DOC   (54 cols)
+ *   AreaPOI                        ACTIVE
  *   AreaTable                      ACTIVE
  *   AreaTrigger                    ACTIVE
  *   AttackAnimKits                 DOC   (5 cols)
@@ -257,7 +257,7 @@
  *   gtRegenHPPerSpt                ACTIVE
  *   gtRegenMPPerSpt                ACTIVE
  *
- *   (103 ACTIVE, 142 DOC)  phantoms: ItemCondExtCosts, gtOCTRegenMP
+ *   (104 ACTIVE, 141 DOC)  phantoms: ItemCondExtCosts, gtOCTRegenMP
  */
 
 // AnimationData -- 8 cols, record_size 32, build 3.3.5.12340. INERT reference (not loaded).
@@ -271,25 +271,6 @@ struct AnimationDataEntry
     int32   Fallback;  // 5
     int32   BehaviorID;  // 6
     int32   BehaviorTier;  // 7
-};
-
-// AreaPOI -- 54 cols, record_size 216, build 3.3.5.12340. INERT reference (not loaded).
-struct AreaPOIEntry
-{
-    uint32  ID;  // 0
-    int32   Importance;  // 1
-    uint32  Icon[9];  // 2-10
-    uint32  FactionID;  // 11
-    float   Pos[3];  // 12-14
-    uint32  ContinentID;  // 15
-    uint32  Flags;  // 16
-    uint32  AreaID;  // 17
-    char*   Name_lang[16];  // 18-33
-// uint32  Name_lang_flags;  // 34
-    char*   Description_lang[16];  // 35-50
-// uint32  Description_lang_flags;  // 51
-    uint32  WorldStateID;  // 52
-    uint32  WorldMapLink;  // 53
 };
 
 // AttackAnimKits -- 5 cols, record_size 20, build 3.3.5.12340. INERT reference (not loaded).

--- a/src/game/Server/DBCfmt.h
+++ b/src/game/Server/DBCfmt.h
@@ -30,6 +30,7 @@ const char Achievementfmt[] = "niixssssssssssssssssxxxxxxxxxxxxxxxxxxiixixxxxxxx
 const char AchievementCriteriafmt[] = "niiiiiiiissssssssssssssssxixiii";
 const char AchievementCategoryfmt[] = "nixxxxxxxxxxxxxxxxxx";
 const char AreaTableEntryfmt[] = "iiinixxxxxissssssssssssssssxiiiiixxx";
+const char AreaPOIEntryfmt[] = "niiiiiiiiiiifffiiissssssssssssssssxxxxxxxxxxxxxxxxxxii";
 const char AreaGroupEntryfmt[] = "niiiiiii";
 const char AreaTriggerEntryfmt[] = "niffffffff";
 const char AuctionHouseEntryfmt[] = "niiixxxxxxxxxxxxxxxxx";

--- a/src/game/WorldHandlers/Chat.cpp
+++ b/src/game/WorldHandlers/Chat.cpp
@@ -289,6 +289,7 @@ ChatCommand* ChatHandler::getCommandTable()
         { "moditemvalue",   SEC_ADMINISTRATOR,  false, &ChatHandler::HandleDebugModItemValueCommand,        "", NULL },
         { "modvalue",       SEC_ADMINISTRATOR,  false, &ChatHandler::HandleDebugModValueCommand,            "", NULL },
         { "play",           SEC_MODERATOR,      false, NULL,                                                "", debugPlayCommandTable },
+        { "poi",            SEC_ADMINISTRATOR,  false, &ChatHandler::HandleDebugPoiCommand,                 "", NULL },
         { "recv",           SEC_ADMINISTRATOR,  false, &ChatHandler::HandleDebugRecvOpcodeCommand,          "", NULL },
         { "send",           SEC_ADMINISTRATOR,  false, NULL,                                                "", debugSendCommandTable },
         { "setaurastate",   SEC_ADMINISTRATOR,  false, &ChatHandler::HandleDebugSetAuraStateCommand,        "", NULL },
@@ -298,6 +299,7 @@ ChatCommand* ChatHandler::getCommandTable()
         { "spellcoefs",     SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleDebugSpellCoefsCommand,          "", NULL },
         { "spellmods",      SEC_ADMINISTRATOR,  false, &ChatHandler::HandleDebugSpellModsCommand,           "", NULL },
         { "uws",            SEC_ADMINISTRATOR,  false, &ChatHandler::HandleDebugUpdateWorldStateCommand,    "", NULL },
+        { "worldstate",     SEC_ADMINISTRATOR,  false, &ChatHandler::HandleDebugWorldStateCommand,          "", NULL },
         { NULL,             0,                  false, NULL,                                                "", NULL }
     };
 

--- a/src/game/WorldHandlers/Chat.h
+++ b/src/game/WorldHandlers/Chat.h
@@ -273,7 +273,9 @@ class ChatHandler
         bool HandleDebugSpellCheckCommand(char* args);
         bool HandleDebugSpellCoefsCommand(char* args);
         bool HandleDebugSpellModsCommand(char* args);
+        bool HandleDebugPoiCommand(char* args);
         bool HandleDebugUpdateWorldStateCommand(char* args);
+        bool HandleDebugWorldStateCommand(char* args);
 
         bool HandleDebugPlayCinematicCommand(char* args);
         bool HandleDebugPlayMovieCommand(char* args);

--- a/src/game/WorldHandlers/GridNotifiers.cpp
+++ b/src/game/WorldHandlers/GridNotifiers.cpp
@@ -100,8 +100,26 @@ void VisibleNotifier::Notify()
     // leftovers below by having been re-found -- which is what makes their out-of-range
     // correct without anybody keeping a list.
 
+    // THE LEFTOVERS SWEEP IS THE THIRD DOOR OUT, and the only one that works on bare
+    // guids -- so the refusal in BuildOutOfRangeUpdateBlock cannot reach it and has to be
+    // repeated here. It matters for the siege vehicles rather than the gunships: a
+    // demolisher is an ordinary grid creature, it IS in m_clientGUIDs, and every time its
+    // driver rode out of a watcher's cells this sweep took it off that watcher's zone map.
+    //
+    // Dropped from the packet, but still erased from m_clientGUIDs below: the server's
+    // bookkeeping stays honest, so coming back into range sends a fresh create, and the
+    // client's list dedups by guid rather than growing a second entry.
+    GuidSet outOfRange;
+    for (GuidSet::const_iterator itr = i_clientGUIDs.begin(); itr != i_clientGUIDs.end(); ++itr)
+    {
+        if (!player.GetMap()->IsZoneMapTrackedGuid(*itr))
+        {
+            outOfRange.insert(*itr);
+        }
+    }
+
     // generate outOfRange for not iterate objects
-    i_data.AddOutOfRangeGUID(i_clientGUIDs);
+    i_data.AddOutOfRangeGUID(outOfRange);
     for (GuidSet::iterator itr = i_clientGUIDs.begin(); itr != i_clientGUIDs.end(); ++itr)
     {
         player.m_clientGUIDs.erase(*itr);

--- a/src/game/WorldHandlers/Map.cpp
+++ b/src/game/WorldHandlers/Map.cpp
@@ -769,6 +769,7 @@ bool Map::Add(Player* player)
 
     SendInitSelf(player);
     SendInitTransports(player);
+    SendInitZoneMapTracked(player);
 
     NGridType* grid = getNGrid(cell.GridX(), cell.GridY());
     player->GetViewPoint().Event_AddedToWorld(&(*grid)(cell.CellX(), cell.CellY()));
@@ -1989,6 +1990,177 @@ void Map::SendInitTransports(Player* player)
         }
 
         TransportMap::AnnounceVessel(vessel, player);
+    }
+}
+
+Map* Map::AnchorWorld()
+{
+    // A deck has no observers of its own worth speaking of: the players who need the icon
+    // are ashore, on the map the vessel sails. Everywhere else a map is its own anchor.
+    if (TransportMap* hull = AsTransport())
+    {
+        Transport* vessel = hull->Vessel();
+
+        // FindMap, NOT GetMap: GetMap asserts, and this is reached before the vessel has a
+        // map at all. Commission() pins the route's grids from inside Transport::Create, so
+        // the deck's creatures load -- and announce themselves -- while the hull she stands
+        // on is still being built. Nobody can be watching yet, so answering "no anchor" is
+        // the truth rather than a fallback: the players who board or sail past later are
+        // served by SendInitZoneMapTracked instead.
+        return vessel ? vessel->FindMap() : NULL;
+    }
+
+    return this;
+}
+
+void Map::RegisterZoneMapTracked(Creature* tracked)
+{
+    if (!tracked)
+    {
+        return;
+    }
+
+    if (std::find(m_zoneMapTracked.begin(), m_zoneMapTracked.end(), tracked) == m_zoneMapTracked.end())
+    {
+        m_zoneMapTracked.push_back(tracked);
+    }
+}
+
+void Map::UnregisterZoneMapTracked(Creature* tracked)
+{
+    m_zoneMapTracked.erase(std::remove(m_zoneMapTracked.begin(), m_zoneMapTracked.end(), tracked),
+                           m_zoneMapTracked.end());
+}
+
+void Map::AppendZoneMapTrackedBlocks(UpdateData& data, Player* observer)
+{
+    for (Creature* tracked : m_zoneMapTracked)
+    {
+        if (tracked->IsInWorld())
+        {
+            tracked->BuildCreateUpdateBlockForPlayer(&data, observer);
+        }
+    }
+}
+
+bool Map::IsZoneMapTrackedGuid(ObjectGuid guid)
+{
+    Map* anchor = AnchorWorld();
+    if (!anchor)
+    {
+        return false;
+    }
+
+    // The lists are tiny -- two gunship units, plus whatever siege vehicles a battle has
+    // standing -- so a walk beats keeping a second index in step with the first.
+    for (Creature* tracked : anchor->m_zoneMapTracked)
+    {
+        if (tracked->GetObjectGuid() == guid)
+        {
+            return true;
+        }
+    }
+
+    MapManager::TransportsByMapType::const_iterator vessels =
+        sMapMgr.m_TransportsByMap.find(anchor->GetId());
+    if (vessels == sMapMgr.m_TransportsByMap.end())
+    {
+        return false;
+    }
+
+    for (Transport* vessel : vessels->second)
+    {
+        TransportMap* hull = vessel->AsMap();
+        if (!hull || vessel->FindMap() != anchor)
+        {
+            continue;
+        }
+
+        for (Creature* tracked : hull->m_zoneMapTracked)
+        {
+            if (tracked->GetObjectGuid() == guid)
+            {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+void Map::SendInitZoneMapTracked(Player* player)
+{
+    // THE ANCHOR, not this map. A player standing on a deck is looking at the world map the
+    // ship sails -- that is the zone whose map he opens with M, and its icons are his to
+    // see. Keying this off the map he is physically on would answer for map 622, which has
+    // no vessels filed under it and is not the map he is looking at.
+    Map* anchor = AnchorWorld();
+    if (!anchor)
+    {
+        return;
+    }
+
+    // The anchor's own -- the siege vehicles of a Wintergrasp or an Isle of Conquest.
+    UpdateData data;
+    anchor->AppendZoneMapTrackedBlocks(data, player);
+
+    // And every deck sailing it, including the one under his feet. A gunship's icon-carrying
+    // unit stands on the vessel's own map, so no cell of the anchor map will ever find it.
+    // The hulls reached him just before this -- SendInitTransports ashore, the vessel loop in
+    // TransportMap::Add aboard -- so the transport guid these blocks name is already held.
+    MapManager::TransportsByMapType::const_iterator vessels =
+        sMapMgr.m_TransportsByMap.find(anchor->GetId());
+    if (vessels != sMapMgr.m_TransportsByMap.end())
+    {
+        for (Transport* vessel : vessels->second)
+        {
+            if (vessel->FindMap() != anchor)
+            {
+                continue;
+            }
+
+            if (TransportMap* hull = vessel->AsMap())
+            {
+                hull->AppendZoneMapTrackedBlocks(data, player);
+            }
+        }
+    }
+
+    if (!data.HasData())
+    {
+        return;
+    }
+
+    WorldPacket packet;
+    data.BuildPacket(&packet, true);
+    player->SendDirectMessage(&packet);
+}
+
+void Map::AnnounceZoneMapTracked(Creature* tracked)
+{
+    Map* anchor = AnchorWorld();
+    if (!anchor || !tracked || !tracked->IsInWorld())
+    {
+        return;
+    }
+
+    // Everyone on the anchor map, with no test of any kind. That is the whole point: the
+    // player who needs to see a demolisher on his map is the one who cannot see it yet.
+    PlayerList const& everyone = anchor->GetPlayers();
+    for (PlayerList::const_iterator itr = everyone.begin(); itr != everyone.end(); ++itr)
+    {
+        Player* observer = itr->getSource();
+        if (!observer)
+        {
+            continue;
+        }
+
+        UpdateData data;
+        tracked->BuildCreateUpdateBlockForPlayer(&data, observer);
+
+        WorldPacket packet;
+        data.BuildPacket(&packet, true);
+        observer->SendDirectMessage(&packet);
     }
 }
 

--- a/src/game/WorldHandlers/Map.h
+++ b/src/game/WorldHandlers/Map.h
@@ -295,6 +295,40 @@ class Map : public GridRefManager<NGridType>
         virtual TransportMap* AsTransport() { return NULL; }
         virtual TransportMap const* AsTransport() const { return NULL; }
 
+        /**
+         * @brief The zone-map icon channel: create blocks by map membership, not by range.
+         *
+         * A unit carrying VEHICLE_FLAG_ZONE_MAP_ICON is drawn on the zone map, and the
+         * client only ever puts one in that list from a CREATE block. Left to the ordinary
+         * visibility sweep, the icon therefore appears when the player walks close enough
+         * to SEE the vehicle -- which is backwards: the icon is the thing that tells him
+         * where it is so he does not have to. So these are announced exactly the way a
+         * vessel is: everyone on the map gets them on entry, and a new one is pushed to
+         * everyone already there. No distance, no cell.
+         */
+        void RegisterZoneMapTracked(Creature* tracked);
+        void UnregisterZoneMapTracked(Creature* tracked);
+        void SendInitZoneMapTracked(Player* player);
+        void AnnounceZoneMapTracked(Creature* tracked);
+
+        /// Create blocks for this map's tracked units, appended for one observer.
+        void AppendZoneMapTrackedBlocks(UpdateData& data, Player* observer);
+
+        /**
+         * @brief Is this guid a zone-map-tracked unit of the world this map anchors to?
+         *
+         * Asked by the leftovers sweep, which holds bare guids and no objects. It must not
+         * be answered by looking the guid up on one map: a gunship's tracked unit lives on
+         * the VESSEL's map, so the moment a player steps ashore the lookup on his own map
+         * comes back empty and the sweep destroys the very thing the flag exists to keep --
+         * the icon vanished exactly when he got off the ship. Anchor and decks, together.
+         */
+        bool IsZoneMapTrackedGuid(ObjectGuid guid);
+
+        /// The map whose players are told about this one's tracked units -- itself, or for
+        /// a vessel's deck the world map she sails.
+        Map* AnchorWorld();
+
         // can't be nullptr for loaded map
         MapPersistentState* GetPersistentState() const { return m_persistentState; }
 
@@ -539,6 +573,10 @@ class Map : public GridRefManager<NGridType>
         /// Cached largest cinematic visibility radius, or 0 when none.
         float m_cinematicVisibilityRadius;
         MapPersistentState* m_persistentState;
+
+        /// Units on THIS map that the client draws on the zone map. Small by construction:
+        /// two gunships plus whatever siege vehicles a battle has up.
+        std::vector<Creature*> m_zoneMapTracked;
 
         MapRefManager m_mapRefManager;
         MapRefManager::iterator m_mapRefIter;

--- a/src/game/WorldHandlers/TransportMap.cpp
+++ b/src/game/WorldHandlers/TransportMap.cpp
@@ -82,17 +82,6 @@ std::string DescribeSpatially(Unit* u)
 
 namespace
 {
-    /// How far above and below a point to look for a surface when placing something on it.
-    constexpr float HULL_SEARCH_UP = 3.0f;
-    constexpr float HULL_SEARCH_DOWN = 6.0f;
-
-    /// Chest height for the obstruction probe, so the plating a unit stands ON is not itself
-    /// read as the thing blocking it.
-    constexpr float HULL_PROBE_HEIGHT = 1.0f;
-
-    /// Bearings tried when sweeping for a free spot around a master.
-    constexpr int HULL_SPOT_BEARINGS = 8;
-
     /**
      * @brief A totem rides the ship it was planted on for as long as it lives, whoever its
      *        master is and wherever they have got to.
@@ -360,44 +349,6 @@ std::optional<Geometry::Placement> TransportMap::PositionOf(WorldObject const& o
     return std::nullopt;
 }
 
-std::optional<Position> TransportMap::FreeSpotNear(WorldObject const& master, float distance2d,
-                                                   float angle) const
-{
-    const auto anchor = PositionOf(master);
-    if (!anchor)
-    {
-        return std::nullopt;                        // its master is not aboard after all
-    }
-
-    // The requested bearing first, then swept around the master: a ship is small and
-    // cluttered, and the one spot the caller asked for is very often out over the rail.
-    for (int step = 0; step < HULL_SPOT_BEARINGS; ++step)
-    {
-        const float bearing = anchor->Facing() + angle +
-                              (step ? (2 * M_PI_F * float(step) / float(HULL_SPOT_BEARINGS)) : 0.0f);
-
-        const float x = anchor->X() + distance2d * std::cos(bearing);
-        const float y = anchor->Y() + distance2d * std::sin(bearing);
-
-        const auto z = SurfaceAt(x, y, anchor->Z(), HULL_SEARCH_UP, HULL_SEARCH_DOWN);
-        if (!z)
-        {
-            continue;                               // out over the rail
-        }
-
-        // ...and nothing solid in between, or we would set a pet down on the far side of a
-        // bulkhead from the master it is supposed to be heeling.
-        if (IsBlocked(Geometry::Vector3(anchor->X(), anchor->Y(), anchor->Z() + HULL_PROBE_HEIGHT),
-                      Geometry::Vector3(x, y, *z + HULL_PROBE_HEIGHT)))
-        {
-            continue;
-        }
-
-        return Position(x, y, *z, anchor->Facing());
-    }
-
-    return std::nullopt;
-}
 
 /* ******************************** Who is aboard ************************************** */
 
@@ -449,9 +400,22 @@ bool TransportMap::Add(Player* passenger)
         }
     }
 
+    // The zone-map icons of the water she is crossing -- his own ship's, and every other
+    // deck's. This override replaces Map::Add wholesale, so nothing here is inherited: the
+    // base class sends this right after SendInitTransports, and skipping it is why a player
+    // logging in at sea had a bare map until he flew ashore. After the vessel loop above,
+    // which is what put those hulls at his client in the first place.
+    SendInitZoneMapTracked(passenger);
+
     NGridType* grid = getNGrid(cell.GridX(), cell.GridY());
     passenger->GetViewPoint().Event_AddedToWorld(&(*grid)(cell.CellX(), cell.CellY()));
     UpdateObjectVisibility(passenger, cell, p);
+
+    // THE OTHER HALF OF IT. The line above notifies cameras on THIS map; the people who
+    // watched him walk up the gangway are on another one, and Map::Remove already gave them
+    // his destroy. Without this they lose him until their own sweep comes round -- he
+    // vanishes off the deck and pops back a second later.
+    AnnounceAboard(passenger);
 
     return true;
 }
@@ -615,6 +579,11 @@ void TransportMap::EnlistCrew(Creature* crew)
     {
         crew->SetPhaseMask(m_vessel->GetPhaseMask(), false);
     }
+
+    // Same event, same audience. At start-up there is nobody in either list and this costs
+    // nothing; mid-voyage it is what makes `.trans npc add` land in front of an audience
+    // instead of waiting for everyone to move.
+    AnnounceAboard(crew);
 }
 
 void TransportMap::DelistCrew(Creature* crew)
@@ -694,24 +663,38 @@ void TransportMap::AppendCrewDestroyBlocks(UpdateData& data)
     }
 }
 
-void TransportMap::SendCrewMemberCreate(Creature* crew)
+void TransportMap::AnnounceAboard(WorldObject* arrival)
 {
-    if (!crew || !crew->IsInWorld() || !m_vessel || !m_vessel->GetMap())
+    if (!arrival || !arrival->IsInWorld())
     {
         return;
     }
 
-    PlayerList const& everyone = m_vessel->GetMap()->GetPlayers();
-    for (PlayerList::const_iterator itr = everyone.begin(); itr != everyone.end(); ++itr)
+    // Ashore first, then aboard. Both lists are empty during Commission(), when the deck's
+    // creatures load before the hull has a map at all -- so this is a no-op then, which is
+    // the right answer: there is nobody to tell.
+    std::vector<Player*> audience = ExternalObservers();
+
+    PlayerList const& aboard = GetPlayers();
+    for (PlayerList::const_iterator itr = aboard.begin(); itr != aboard.end(); ++itr)
     {
-        Player* observer = itr->getSource();
-        if (!observer)
+        if (Player* mate = itr->getSource())
+        {
+            audience.push_back(mate);
+        }
+    }
+
+    for (Player* observer : audience)
+    {
+        // He does not need to be told about himself: his own create block reached him
+        // ahead of the vessel's, which is the one ordering that matters here.
+        if (observer == arrival || !observer->IsInWorld())
         {
             continue;
         }
 
         UpdateData data;
-        crew->BuildCreateUpdateBlockForPlayer(&data, observer);
+        arrival->BuildCreateUpdateBlockForPlayer(&data, observer);
 
         WorldPacket packet;
         data.BuildPacket(&packet, true);
@@ -810,6 +793,56 @@ void TransportMap::CollectRelaySources(WorldObject const* viewer, float visibili
         // The whole ship, swept from her origin. Her space is small and a crew is a few
         // dozen, so a radius that certainly covers the hull is cheaper than being exact.
         out.push_back({hull, 0.0f, 0.0f, hull->HullRadius() * 2.0f + visibility});
+    }
+}
+
+void TransportMap::CollectRelayAudience(WorldObject const* obj, std::vector<Player*>& out)
+{
+    Map* on = obj ? obj->FindMap() : NULL;
+    if (!on)
+    {
+        return;
+    }
+
+    // Aboard: the shore watch, gathered once a tick on everyone's behalf.
+    if (TransportMap* hull = on->AsTransport())
+    {
+        std::vector<Player*> const& ashore = hull->ExternalObservers();
+        out.insert(out.end(), ashore.begin(), ashore.end());
+        return;
+    }
+
+    // Ashore: the passengers of every vessel near enough to be looking. Most maps carry no
+    // vessel at all and stop at the lookup; Icecrown carries two.
+    MapManager::TransportsByMapType::const_iterator vessels =
+        sMapMgr.m_TransportsByMap.find(on->GetId());
+    if (vessels == sMapMgr.m_TransportsByMap.end())
+    {
+        return;
+    }
+
+    for (Transport* vessel : vessels->second)
+    {
+        TransportMap* hull = vessel->AsMap();
+        if (!hull || vessel->FindMap() != on)
+        {
+            continue;
+        }
+
+        const float reach = on->GetVisibilityDistance() + hull->HullRadius() + vessel->NodeSlack();
+        if (!vessel->Where().WithinDist(obj->Where(), reach, false))
+        {
+            continue;
+        }
+
+        PlayerList const& aboard = hull->GetPlayers();
+        for (PlayerList::const_iterator itr = aboard.begin(); itr != aboard.end(); ++itr)
+        {
+            if (Player* mate = itr->getSource())
+            {
+                out.push_back(mate);
+            }
+        }
     }
 }
 

--- a/src/game/WorldHandlers/TransportMap.h
+++ b/src/game/WorldHandlers/TransportMap.h
@@ -136,16 +136,6 @@ class TransportMap : public Map
         /// True when the hull's own geometry stands between two points on it.
         bool IsBlocked(Geometry::Vector3 const& from, Geometry::Vector3 const& to) const;
 
-        /**
-         * @brief A spot `distance2d` yards from `master` at its facing plus `angle`.
-         *
-         * The requested bearing is tried first and then swept around the master, because a
-         * ship is small and cluttered and the one spot asked for is very often out over the
-         * rail. Nothing when `master` is not aboard.
-         */
-        std::optional<Position> FreeSpotNear(WorldObject const& master, float distance2d,
-                                             float angle) const;
-
         /// Where something aboard stands, or nothing when it is not on this ship. There is
         /// nothing to look up and nothing to convert: this map's coordinates are the answer.
         std::optional<Geometry::Placement> PositionOf(WorldObject const& obj) const;
@@ -191,7 +181,6 @@ class TransportMap : public Map
          */
         void EnlistCrew(Creature* crew);
         void DelistCrew(Creature* crew);
-        bool HasCrew() const { return !m_crew.empty(); }
 
         /// Drop the index at shutdown. The creatures are this map's to destroy, like any
         /// other map's.
@@ -221,9 +210,36 @@ class TransportMap : public Map
         static void CollectRelaySources(WorldObject const* viewer, float visibility,
                                         std::vector<RelaySource>& out);
 
-        /// One newly-arrived crew member, announced to everyone already watching. `.trans npc
-        /// add` boards mid-voyage, with an audience.
-        void SendCrewMemberCreate(Creature* crew);
+        /**
+         * @brief The players on the far side of a vessel boundary who must hear about `obj`.
+         *
+         * The twin of CollectRelaySources, for BROADCAST rather than for a cell sweep. That
+         * one answers "where else must I look"; this one answers "who else must be told",
+         * and the two are needed in different places for the same reason: a deck and the
+         * shore are two maps, and a cell visit of one never reaches the other.
+         *
+         * Without it a value update never crosses at all -- the accumulator behind
+         * BuildUpdateData visits cameras in cells around the object, and every camera that
+         * matters here is on the other map. A deckhand killed at sea stayed standing for
+         * everyone ashore; a quest giver on the pier stayed frozen for everyone aboard.
+         */
+        static void CollectRelayAudience(WorldObject const* obj, std::vector<Player*>& out);
+
+        /**
+         * @brief ONE object has just arrived aboard: tell everyone who is watching this ship.
+         *
+         * Arriving aboard is a single event whoever you are -- a deckhand boarded by
+         * `.trans npc add` mid-voyage, a passenger who walked up the gangway, a pet drawn
+         * across behind its master. The audience is the same in every case: the players
+         * already on this map, and the observers ashore.
+         *
+         * It exists because neither half of that audience is reached by anything else. A
+         * player ashore is not a camera on this map, so `Map::Add`'s visibility pass never
+         * touches him; his own sweep would find the arrival eventually, but only when he
+         * moves or when the periodic observer sweep comes round -- so a man on the pier
+         * watched his friend walk aboard, vanish, and reappear a second later.
+         */
+        void AnnounceAboard(WorldObject* arrival);
 
         /// Append the crew's create blocks to a packet already carrying the vessel's.
         /// Deliberately does NOT stamp m_clientGUIDs: they ride the vessel's map-membership

--- a/src/game/WorldHandlers/UpdateBlockLayout.cpp
+++ b/src/game/WorldHandlers/UpdateBlockLayout.cpp
@@ -1,0 +1,70 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "UpdateBlockLayout.h"
+
+namespace UpdateBlock
+{
+    void WriteMovementTail(ByteBuffer& data, uint16 updateFlags, MovementTail const& tail)
+    {
+        // 0x08
+        if (updateFlags & UPDATEFLAG_LOWGUID)
+        {
+            data << uint32(tail.lowGuid);
+        }
+
+        // 0x10
+        if (updateFlags & UPDATEFLAG_HIGHGUID)
+        {
+            data << uint32(tail.highGuid);
+        }
+
+        // 0x04 -- packed guid of the current target
+        if (updateFlags & UPDATEFLAG_HAS_ATTACKING_TARGET)
+        {
+            data.appendPackGUID(tail.attackingTarget);
+        }
+
+        // 0x02
+        if (updateFlags & UPDATEFLAG_TRANSPORT)
+        {
+            data << uint32(tail.transportTime);
+        }
+
+        // 0x80 -- in the binary this is a sign-bit test on the low byte, right here,
+        // between the transport word and the rotation. Not last, not numeric.
+        if (updateFlags & UPDATEFLAG_VEHICLE)
+        {
+            data << uint32(tail.vehicleId);
+            data << float(tail.vehicleFacing);
+        }
+
+        // 0x200
+        if (updateFlags & UPDATEFLAG_ROTATION)
+        {
+            data << int64(tail.rotation);
+        }
+    }
+}

--- a/src/game/WorldHandlers/UpdateBlockLayout.h
+++ b/src/game/WorldHandlers/UpdateBlockLayout.h
@@ -1,0 +1,93 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_H_UPDATEBLOCKLAYOUT
+#define MANGOS_H_UPDATEBLOCKLAYOUT
+
+#include "ByteBuffer.h"
+
+/**
+ * The bits of the `uint16` that opens an object's movement block.
+ */
+enum ObjectUpdateFlags
+{
+    UPDATEFLAG_NONE                 = 0x0000,
+    UPDATEFLAG_SELF                 = 0x0001,
+    UPDATEFLAG_TRANSPORT            = 0x0002,
+    UPDATEFLAG_HAS_ATTACKING_TARGET = 0x0004,
+    UPDATEFLAG_LOWGUID              = 0x0008,
+    UPDATEFLAG_HIGHGUID             = 0x0010,
+    UPDATEFLAG_LIVING               = 0x0020,
+    UPDATEFLAG_HAS_POSITION         = 0x0040,
+    UPDATEFLAG_VEHICLE              = 0x0080,
+    UPDATEFLAG_POSITION             = 0x0100,
+    UPDATEFLAG_ROTATION             = 0x0200
+};
+
+namespace UpdateBlock
+{
+    /**
+     * @brief Everything the tail of a movement block can carry, already resolved.
+     *
+     * The values are the caller's business -- which magic constant a unit's "low guid"
+     * word actually holds, whose facing the vehicle block sends. Only the ORDER is this
+     * unit's business, and it lives here so it can be pinned by a test.
+     */
+    struct MovementTail
+    {
+        uint32 lowGuid = 0;                 ///< UPDATEFLAG_LOWGUID
+        uint32 highGuid = 0;                ///< UPDATEFLAG_HIGHGUID
+        uint64 attackingTarget = 0;         ///< UPDATEFLAG_HAS_ATTACKING_TARGET, sent packed
+        uint32 transportTime = 0;           ///< UPDATEFLAG_TRANSPORT: path progress, not a clock
+        uint32 vehicleId = 0;               ///< UPDATEFLAG_VEHICLE: the Vehicle.dbc row id
+        float  vehicleFacing = 0.0f;        ///< UPDATEFLAG_VEHICLE: the icon's rotation on the map
+        int64  rotation = 0;                ///< UPDATEFLAG_ROTATION, packed quaternion
+    };
+
+    /**
+     * @brief Write the tail of a movement block: everything after the position section.
+     *
+     * THE ORDER IS NOT NUMERIC, and nobody guesses it right twice. The 3.3.5a client's
+     * parser reads
+     *
+     *     0x08 LOWGUID -> 0x10 HIGHGUID -> 0x04 HAS_ATTACKING_TARGET
+     *          -> 0x02 TRANSPORT -> 0x80 VEHICLE -> 0x200 ROTATION
+     *
+     * -- confirmed against the 12340 binary, where the vehicle branch is not a flag test
+     * at all but a sign-bit test on the low byte of the flag word (`0x80`), sitting
+     * between the transport word and the rotation. Put the vehicle block anywhere else
+     * and every field after it is read from the wrong offset: the client does not
+     * validate, it just believes the stream.
+     *
+     * That block is also the ONLY reason an Icecrown gunship can be an icon on the zone
+     * map. The client fills its battlefield-vehicle list exclusively from the CREATE
+     * path, gated on the unit having a Vehicle.dbc row whose Flags carry 0x10000000 --
+     * so a vehicle id arriving later, by SMSG_SET_VEHICLE_REC_ID, attaches the component
+     * and still never draws an icon.
+     */
+    void WriteMovementTail(ByteBuffer& data, uint16 updateFlags, MovementTail const& tail);
+}
+
+#endif

--- a/src/game/WorldHandlers/UpdateData.h
+++ b/src/game/WorldHandlers/UpdateData.h
@@ -28,6 +28,8 @@
 
 #include "ByteBuffer.h"
 #include "ObjectGuid.h"
+// ObjectUpdateFlags lives with the writer that orders them, so the two cannot drift.
+#include "UpdateBlockLayout.h"
 
 class WorldPacket;
 
@@ -39,21 +41,6 @@ enum ObjectUpdateType
     UPDATETYPE_CREATE_OBJECT2       = 3,
     UPDATETYPE_OUT_OF_RANGE_OBJECTS = 4,
     UPDATETYPE_NEAR_OBJECTS         = 5
-};
-
-enum ObjectUpdateFlags
-{
-    UPDATEFLAG_NONE                 = 0x0000,
-    UPDATEFLAG_SELF                 = 0x0001,
-    UPDATEFLAG_TRANSPORT            = 0x0002,
-    UPDATEFLAG_HAS_ATTACKING_TARGET = 0x0004,
-    UPDATEFLAG_LOWGUID              = 0x0008,
-    UPDATEFLAG_HIGHGUID             = 0x0010,
-    UPDATEFLAG_LIVING               = 0x0020,
-    UPDATEFLAG_HAS_POSITION         = 0x0040,
-    UPDATEFLAG_VEHICLE              = 0x0080,
-    UPDATEFLAG_POSITION             = 0x0100,
-    UPDATEFLAG_ROTATION             = 0x0200
 };
 
 class UpdateData

--- a/src/game/WorldHandlers/World.cpp
+++ b/src/game/WorldHandlers/World.cpp
@@ -111,6 +111,7 @@
 #include "GitRevision.h"
 #include "UpdateTime.h"
 #include "GameTime.h"
+#include "WorldStateMgr.h"
 
 #ifdef ENABLE_ELUNA
 #include "LuaEngine.h"
@@ -974,6 +975,10 @@ void World::SetInitialWorldSettings()
     ///- Initialize Outdoor PvP
     sLog.outString("Starting Outdoor PvP System");
     sOutdoorPvPMgr.InitOutdoorPvP();
+
+    ///- Index the map landmarks the world states drive (AreaPOI.dbc)
+    sLog.outString("Starting World State store");
+    sWorldStateMgr.Initialize();
 
     // Not sure if this can be moved up in the sequence (with static data loading) as it uses MapManager
     sLog.outString("Loading Transports...");

--- a/src/game/WorldHandlers/WorldStateMgr.cpp
+++ b/src/game/WorldHandlers/WorldStateMgr.cpp
@@ -1,0 +1,243 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "WorldStateMgr.h"
+
+#include "DBCStores.h"
+#include "DBCStructure.h"
+#include "Log.h"
+#include "Opcodes.h"
+#include "Player.h"
+#include "World.h"
+#include "WorldPacket.h"
+#include "WorldSession.h"
+
+namespace
+{
+    /// Returned by reference for a state no landmark uses, so callers need no null check.
+    std::vector<AreaPOIEntry const*> const s_noPois;
+
+    /// The highest icon slot a row carries. The client clamps anything above this to
+    /// Icon[0] rather than reading past the row, so a larger value is not a crash --
+    /// it is just an icon nobody meant.
+    const uint32 MAX_POI_ICON_SLOT = 9;
+}
+
+void WorldStateMgr::Initialize()
+{
+    m_poiByState.clear();
+
+    uint32 gated = 0;
+    for (uint32 i = 0; i < sAreaPOIStore.GetNumRows(); ++i)
+    {
+        AreaPOIEntry const* poi = sAreaPOIStore.LookupEntry(i);
+        if (!poi)
+        {
+            continue;
+        }
+
+        // A row with no world state is drawn unconditionally and the server has no say
+        // in it whatsoever -- there is nothing to index and nothing to send.
+        if (!poi->WorldStateID)
+        {
+            continue;
+        }
+
+        m_poiByState[poi->WorldStateID].push_back(poi);
+        ++gated;
+    }
+
+    sLog.outString(">> Indexed %u map landmark(s) driven by a world state, over %u state(s)",
+                   gated, uint32(m_poiByState.size()));
+}
+
+uint32 WorldStateMgr::GetState(uint32 zoneId, uint32 stateId) const
+{
+    std::shared_lock<std::shared_mutex> guard(m_lock);
+
+    StateZoneMap::const_iterator zone = m_states.find(zoneId);
+    if (zone == m_states.end())
+    {
+        return 0;
+    }
+
+    StateValueMap::const_iterator state = zone->second.find(stateId);
+    return state != zone->second.end() ? state->second : 0;
+}
+
+bool WorldStateMgr::SetState(uint32 zoneId, uint32 stateId, uint32 value)
+{
+    if (!stateId)
+    {
+        return false;
+    }
+
+    {
+        std::unique_lock<std::shared_mutex> guard(m_lock);
+
+        uint32& stored = m_states[zoneId][stateId];
+        if (stored == value)
+        {
+            return false;
+        }
+
+        stored = value;
+    }
+
+    // Outside the lock. Broadcast walks every session and writes to sockets; holding a
+    // write lock across that would stall every map thread reading a landmark's state
+    // for as long as the slowest client's send buffer takes.
+    Broadcast(zoneId, stateId, value);
+    return true;
+}
+
+bool WorldStateMgr::SetPoiState(uint32 poiId, uint32 value)
+{
+    AreaPOIEntry const* poi = sAreaPOIStore.LookupEntry(poiId);
+    if (!poi)
+    {
+        sLog.outError("WorldStateMgr: no AreaPOI row %u", poiId);
+        return false;
+    }
+
+    if (!poi->WorldStateID)
+    {
+        sLog.outError("WorldStateMgr: AreaPOI %u carries no world state -- the client "
+                      "draws it unconditionally and the server cannot change it", poiId);
+        return false;
+    }
+
+    if (value > MAX_POI_ICON_SLOT)
+    {
+        sLog.outError("WorldStateMgr: AreaPOI %u given icon slot %u; the row holds %u, "
+                      "and the client clamps anything past it back to the first icon",
+                      poiId, value, MAX_POI_ICON_SLOT);
+    }
+
+    return SetState(ZoneOfPoi(*poi), poi->WorldStateID, value);
+}
+
+void WorldStateMgr::FillInitialStates(uint32 zoneId, ByteBuffer& data, uint32& count) const
+{
+    std::shared_lock<std::shared_mutex> guard(m_lock);
+
+    // Zone 0 first, then the zone's own: a zone may deliberately override a global
+    // default, and the client keeps whichever value it was told last.
+    const uint32 keys[2] = { 0, zoneId };
+    for (int i = 0; i < 2; ++i)
+    {
+        if (i == 1 && zoneId == 0)
+        {
+            break;
+        }
+
+        StateZoneMap::const_iterator zone = m_states.find(keys[i]);
+        if (zone == m_states.end())
+        {
+            continue;
+        }
+
+        for (StateValueMap::const_iterator itr = zone->second.begin();
+             itr != zone->second.end(); ++itr)
+        {
+            data << uint32(itr->first);
+            data << uint32(itr->second);
+            ++count;
+        }
+    }
+}
+
+std::vector<AreaPOIEntry const*> const& WorldStateMgr::PoisOfState(uint32 stateId) const
+{
+    std::unordered_map<uint32, std::vector<AreaPOIEntry const*> >::const_iterator itr =
+        m_poiByState.find(stateId);
+
+    return itr != m_poiByState.end() ? itr->second : s_noPois;
+}
+
+std::vector<AreaPOIEntry const*> WorldStateMgr::PoisOfZone(uint32 zoneId) const
+{
+    std::vector<AreaPOIEntry const*> found;
+
+    for (std::unordered_map<uint32, std::vector<AreaPOIEntry const*> >::const_iterator itr =
+             m_poiByState.begin(); itr != m_poiByState.end(); ++itr)
+    {
+        for (AreaPOIEntry const* poi : itr->second)
+        {
+            if (ZoneOfPoi(*poi) == zoneId)
+            {
+                found.push_back(poi);
+            }
+        }
+    }
+
+    return found;
+}
+
+uint32 WorldStateMgr::ZoneOfPoi(AreaPOIEntry const& poi)
+{
+    // AreaPOI names an AREA, and an area is often a sub-zone -- "Wintergrasp Fortress"
+    // rather than "Wintergrasp". The client is told world states per ZONE, so the walk up
+    // to the parent is what makes the key match what the player will be standing in.
+    AreaTableEntry const* area = GetAreaEntryByAreaID(poi.AreaID);
+    if (!area)
+    {
+        return 0;
+    }
+
+    return area->ParentAreaID ? area->ParentAreaID : area->ID;
+}
+
+void WorldStateMgr::Broadcast(uint32 zoneId, uint32 stateId, uint32 value) const
+{
+    WorldPacket data(SMSG_UPDATE_WORLD_STATE, 4 + 4);
+    data << uint32(stateId);
+    data << uint32(value);
+
+    SessionMap const& sessions = sWorld.GetAllSessions();
+    for (SessionMap::const_iterator itr = sessions.begin(); itr != sessions.end(); ++itr)
+    {
+        WorldSession* session = itr->second;
+        if (!session)
+        {
+            continue;
+        }
+
+        Player* player = session->GetPlayer();
+        if (!player || !player->IsInWorld())
+        {
+            continue;
+        }
+
+        // Zone 0 is everyone; anything else only reaches the players who are being told
+        // about that zone in the first place, and who will be told again on the way in.
+        if (zoneId && player->GetCachedZoneId() != zoneId)
+        {
+            continue;
+        }
+
+        session->SendPacket(&data);
+    }
+}

--- a/src/game/WorldHandlers/WorldStateMgr.h
+++ b/src/game/WorldHandlers/WorldStateMgr.h
@@ -1,0 +1,133 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_H_WORLDSTATEMGR
+#define MANGOS_H_WORLDSTATEMGR
+
+#include "Platform/Define.h"
+#include "Policies/Singleton.h"
+
+#include <map>
+#include <mutex>
+#include <shared_mutex>
+#include <unordered_map>
+#include <vector>
+
+class ByteBuffer;
+struct AreaPOIEntry;
+
+/**
+ * @brief The world state store -- the one number a map landmark is drawn from.
+ *
+ * A LANDMARK IS NOT AN OBJECT. The fixed points the client draws on a zone map -- the
+ * Wintergrasp towers, the walls, the gates, the workshops -- are not creatures, not
+ * gameobjects and not anything the server can move. They are rows in AreaPOI.dbc, which
+ * the server never sends and the client already has. All the server ever contributes is
+ * ONE `uint32` per row:
+ *
+ *   value 0        the landmark is not drawn at all
+ *   value 1..9     the landmark is drawn with Icon[value - 1] from its own row
+ *
+ * The client clamps the index to 0..8 and recomputes it on every query, so a change of
+ * state repaints the icon with no list rebuild; only crossing zero adds or removes the
+ * landmark. That is the whole mechanism. It costs two packets:
+ * `SMSG_INIT_WORLD_STATES` when a player enters a zone, and `SMSG_UPDATE_WORLD_STATE`
+ * whenever a value moves after that.
+ *
+ * THE ZONE IS PART OF THE KEY. The client keeps world states in one flat table with no
+ * zone in it, but it is told them per zone and it is told them again on every zone
+ * change -- so a state seeded for Wintergrasp must not follow a player to Icecrown, or
+ * the two would overwrite each other in that flat table. Zone 0 is the exception and
+ * means "everywhere": the arena season, the Wintergrasp countdown, anything the client
+ * is expected to know regardless of where it is standing.
+ *
+ * This store is DELIBERATELY not the battleground one. A BattleGround fills its own
+ * states from its own live state on demand, because they change per match; these are
+ * durable world facts with no owner to ask, so they are kept here and pushed.
+ */
+class WorldStateMgr
+{
+    public:
+        WorldStateMgr() {}
+        ~WorldStateMgr() {}
+
+        /// Index AreaPOI.dbc by world state. Call once, after the DBCs are loaded.
+        void Initialize();
+
+        /// Current value, or 0 when nothing has ever set it -- which is also "not drawn".
+        uint32 GetState(uint32 zoneId, uint32 stateId) const;
+
+        /**
+         * @brief Store a world state and push it to everyone who can see it.
+         * @return true when the value actually changed; false when it already held it.
+         *
+         * The push is edge-triggered on purpose: re-sending an unchanged value costs a
+         * packet per player and buys nothing, since the client stores what it was told.
+         */
+        bool SetState(uint32 zoneId, uint32 stateId, uint32 value);
+
+        /**
+         * @brief Set the landmark's icon by AreaPOI id, resolving zone and state from the row.
+         * @param poiId AreaPOI.dbc row id.
+         * @param value 0 hides the landmark, 1..9 selects Icon[value - 1].
+         * @return false when the row is unknown or carries no world state to move.
+         */
+        bool SetPoiState(uint32 poiId, uint32 value);
+
+        /// Append every state known for this zone (plus the global ones) to an init packet.
+        void FillInitialStates(uint32 zoneId, ByteBuffer& data, uint32& count) const;
+
+        /// The AreaPOI rows a world state drives, empty when it drives none.
+        std::vector<AreaPOIEntry const*> const& PoisOfState(uint32 stateId) const;
+
+        /// Every AreaPOI row that carries a world state and sits in this zone.
+        std::vector<AreaPOIEntry const*> PoisOfZone(uint32 zoneId) const;
+
+        /// The zone a landmark belongs to -- AreaPOI names an area, which may be a sub-zone.
+        static uint32 ZoneOfPoi(AreaPOIEntry const& poi);
+
+    private:
+        typedef std::map<uint32, uint32> StateValueMap;      ///< stateId -> value, ordered so
+                                                             ///< the init packet is stable
+        typedef std::unordered_map<uint32, StateValueMap> StateZoneMap;
+
+        /// Send one SMSG_UPDATE_WORLD_STATE to every player the zone key covers.
+        void Broadcast(uint32 zoneId, uint32 stateId, uint32 value) const;
+
+        /// Reads come from anywhere, including map threads; only the push is the world
+        /// thread's, because it walks the session map.
+        mutable std::shared_mutex m_lock;
+        StateZoneMap m_states;
+
+        /// Built once at start-up from AreaPOI.dbc and then only read, so it needs no lock.
+        std::unordered_map<uint32, std::vector<AreaPOIEntry const*> > m_poiByState;
+};
+
+/**
+ * @brief Global world state store instance
+ */
+#define sWorldStateMgr MaNGOS::Singleton<WorldStateMgr>::Instance()
+
+#endif

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ set(SRC_GRP_TESTS
     PlacementTest.cpp
     ArbiterModelTest.cpp
     ShadowClassifierTest.cpp
+    UpdateBlockLayoutTest.cpp
     GeometryMathTest.cpp
     DataIntegrityTest.cpp
     LFGLogicTest.cpp
@@ -85,6 +86,7 @@ set(SRC_GRP_TESTS
     ${CMAKE_SOURCE_DIR}/src/game/WorldHandlers/DynamicCollision.cpp
     ${CMAKE_SOURCE_DIR}/src/game/WorldHandlers/GameObjectModel.cpp
     ${CMAKE_SOURCE_DIR}/src/game/WorldHandlers/LFGLogic.cpp
+    ${CMAKE_SOURCE_DIR}/src/game/WorldHandlers/UpdateBlockLayout.cpp
     ${CMAKE_SOURCE_DIR}/src/game/Server/SessionMailbox.cpp
     ${CMAKE_SOURCE_DIR}/src/game/Server/WorldGatewayAuth.cpp
     # The movement arbiter's pure core: no Unit, no driver, no map.

--- a/src/tests/UpdateBlockLayoutTest.cpp
+++ b/src/tests/UpdateBlockLayoutTest.cpp
@@ -1,0 +1,167 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "TestHarness.h"
+
+#include "UpdateBlockLayout.h"
+
+/**
+ * @file
+ * @brief The create block's movement tail, pinned byte for byte.
+ *
+ * THE ORDER IS NOT NUMERIC. The 3.3.5a client reads the tail as
+ *
+ *     0x08 LOWGUID -> 0x10 HIGHGUID -> 0x04 HAS_ATTACKING_TARGET
+ *          -> 0x02 TRANSPORT -> 0x80 VEHICLE -> 0x200 ROTATION
+ *
+ * which is neither ascending nor descending, and which nobody reconstructs correctly
+ * from memory. It was read out of the 12340 binary's parser, where the vehicle branch
+ * is not even a flag test -- it is a sign-bit test on the low byte of the flag word,
+ * sitting between the transport word and the rotation.
+ *
+ * The failure mode is why this is worth a test at all: get the order wrong and nothing
+ * rejects the packet. The client has no length check and no validation here; it just
+ * keeps reading, so every field after the mistake is decoded from the wrong offset.
+ * A vehicle id lands in the rotation, a facing becomes a guid, and what you see is a
+ * unit at the wrong place -- or nothing at all -- with no error anywhere.
+ *
+ * These bytes are also the only thing that makes an Icecrown gunship an icon on the
+ * zone map: the client fills its battlefield-vehicle list exclusively from the CREATE
+ * path, so the vehicle id has to be in this block and not in a later
+ * SMSG_SET_VEHICLE_REC_ID.
+ */
+
+namespace
+{
+    std::string TailHex(uint16 flags, UpdateBlock::MovementTail const& tail)
+    {
+        ByteBuffer buf;
+        UpdateBlock::WriteMovementTail(buf, flags, tail);
+        return testing::BytesToHex(buf.contents(), buf.size());
+    }
+
+    /// A tail whose every field is distinguishable from every other in the hex dump.
+    UpdateBlock::MovementTail SampleTail()
+    {
+        UpdateBlock::MovementTail tail;
+        tail.lowGuid = 0x0000000B;                          // what a unit actually sends
+        tail.highGuid = 0x0000000B;
+        tail.attackingTarget = 0x0000000000000005ULL;       // packs to 01 05
+        tail.transportTime = 0x11223344;
+        tail.vehicleId = 245;                               // Vehicle.dbc 245, Orgrim's Hammer
+        tail.vehicleFacing = 1.0f;                          // 0x3F800000, exact
+        tail.rotation = 0x0102030405060708LL;
+        return tail;
+    }
+}
+
+TEST(UpdateBlock_flag_bits_are_the_wire_values)
+{
+    // Renumbering these is renumbering the protocol. Nothing else in the tree would
+    // notice; the client would simply read a different block than the one sent.
+    CHECK_EQ(int(UPDATEFLAG_SELF), 0x0001);
+    CHECK_EQ(int(UPDATEFLAG_TRANSPORT), 0x0002);
+    CHECK_EQ(int(UPDATEFLAG_HAS_ATTACKING_TARGET), 0x0004);
+    CHECK_EQ(int(UPDATEFLAG_LOWGUID), 0x0008);
+    CHECK_EQ(int(UPDATEFLAG_HIGHGUID), 0x0010);
+    CHECK_EQ(int(UPDATEFLAG_LIVING), 0x0020);
+    CHECK_EQ(int(UPDATEFLAG_HAS_POSITION), 0x0040);
+    CHECK_EQ(int(UPDATEFLAG_VEHICLE), 0x0080);
+    CHECK_EQ(int(UPDATEFLAG_POSITION), 0x0100);
+    CHECK_EQ(int(UPDATEFLAG_ROTATION), 0x0200);
+}
+
+TEST(UpdateBlock_tail_writes_the_whole_queue_in_client_order)
+{
+    const uint16 flags = UPDATEFLAG_LOWGUID | UPDATEFLAG_HIGHGUID |
+                         UPDATEFLAG_HAS_ATTACKING_TARGET | UPDATEFLAG_TRANSPORT |
+                         UPDATEFLAG_VEHICLE | UPDATEFLAG_ROTATION;
+
+    //  0b000000            low guid       (0x08)
+    //  0b000000            high guid      (0x10)
+    //  0105                packed target  (0x04)
+    //  44332211            transport time (0x02)
+    //  f5000000 0000803f   vehicle id + facing (0x80)
+    //  0807060504030201    packed rotation     (0x200)
+    CHECK_STR(TailHex(flags, SampleTail()),
+              std::string("0b0000000b0000000105"
+                          "44332211"
+                          "f5000000"
+                          "0000803f"
+                          "0807060504030201"));
+}
+
+TEST(UpdateBlock_tail_order_is_not_the_numeric_order_of_the_flags)
+{
+    // 0x04 is numerically before 0x08, and goes out AFTER it. Sorting the queue -- the
+    // obvious "tidy-up" -- breaks the wire precisely here.
+    UpdateBlock::MovementTail tail = SampleTail();
+
+    CHECK_STR(TailHex(UPDATEFLAG_LOWGUID | UPDATEFLAG_HAS_ATTACKING_TARGET, tail),
+              std::string("0b0000000105"));
+}
+
+TEST(UpdateBlock_vehicle_sits_between_the_transport_word_and_the_rotation)
+{
+    UpdateBlock::MovementTail tail = SampleTail();
+
+    // Transport time, then the vehicle pair, then the rotation. Moving the vehicle block
+    // to the end -- where its 0x80 bit would put it if the order were numeric -- gives
+    // the client a rotation where it expects a vehicle id.
+    CHECK_STR(TailHex(UPDATEFLAG_TRANSPORT | UPDATEFLAG_VEHICLE | UPDATEFLAG_ROTATION, tail),
+              std::string("44332211"
+                          "f5000000"
+                          "0000803f"
+                          "0807060504030201"));
+}
+
+TEST(UpdateBlock_vehicle_block_is_a_uint32_id_then_a_float_facing)
+{
+    UpdateBlock::MovementTail tail;
+    tail.vehicleId = 230;                                   // Vehicle.dbc 230, The Skybreaker
+    tail.vehicleFacing = -2.0f;                             // 0xC0000000, exact
+
+    // Eight bytes, in that order. The facing is not decoration: the client rotates the
+    // map icon by it (SetRotation(orientation) in WorldMapFrame.lua), so a swapped pair
+    // here is a ship pointing wherever its vehicle id happened to look like as a float.
+    CHECK_STR(TailHex(UPDATEFLAG_VEHICLE, tail), std::string("e6000000000000c0"));
+}
+
+TEST(UpdateBlock_absent_flags_write_nothing)
+{
+    // A create block for a plain gameobject carries none of the tail. Writing a field
+    // for a flag that is not set shifts everything the client reads afterwards.
+    CHECK_STR(TailHex(UPDATEFLAG_LIVING | UPDATEFLAG_HAS_POSITION, SampleTail()),
+              std::string(""));
+}
+
+TEST(UpdateBlock_an_empty_attacking_target_still_writes_its_packed_zero)
+{
+    // No victim is not "no field": the flag is what the client keys on, and a packed
+    // zero guid is one byte. Skipping it truncates the block.
+    UpdateBlock::MovementTail tail;
+
+    CHECK_STR(TailHex(UPDATEFLAG_HAS_ATTACKING_TARGET, tail), std::string("00"));
+}


### PR DESCRIPTION
Two separate client mechanisms draw icons on the zone map. The server implemented neither, which is why the Icecrown gunships and the Wintergrasp towers have never appeared on anyone's map.

### Vehicles — the moving icons

A unit whose `Vehicle.dbc` row carries `0x10000000` is drawn as a rotating icon, positioned and oriented entirely client-side. The client fills that list from **CREATE blocks alone** and empties an entry only on **DESTROY** — range plays no part on either side. So it is a map-membership channel, not a visibility one:

- announced to every player on the map, on entry and on spawn;
- never sent an out-of-range or destroy block, at any of the three places one can leave from.

This puts the Icecrown gunships on the map as soon as their crew is spawned, and fixes the Wintergrasp and Isle of Conquest siege vehicles, which until now appeared only once you were close enough to see them without the icon.

### Landmarks — the fixed icons with state

`AreaPOI.dbc` is now loaded, and `WorldStateMgr` keeps world states per zone: it fills `SMSG_INIT_WORLD_STATES` on zone entry and pushes `SMSG_UPDATE_WORLD_STATE` on change. A landmark is drawn only while its world state is non-zero, with `Icon[value - 1]`.

That is the whole of what draws the Wintergrasp towers, walls, gates and workshops with their damage state. `.debug poi` lists a zone's landmarks with the state each reads; `.debug worldstate` reads or sets one.

### Also

- The create block's movement tail moves into `UpdateBlockLayout`, with a test pinning its bytes. The order is non-numeric (`0x08 → 0x10 → 0x04 → 0x02 → 0x80 → 0x200`) and the client does not validate, so getting it wrong decodes every later field from the wrong offset with no error anywhere.
- `VEHICLE_FLAG_UNK20` → `VEHICLE_FLAG_ZONE_MAP_ICON`. The old name carried a guess ("Vehicle not dismissed after eject passenger?") that is not what the client does with the bit. No behaviour change at its one use site.

### Notes

- The gunship crew itself is DB data and belongs in the `mangostwo/database` repo: creatures `30342` / `30343` on maps `622` / `623`, with `VehicleTemplateId` 245 / 230.
- Builds clean on MSVC, GCC and Clang; `ctest` 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/275)
<!-- Reviewable:end -->
