### PR TITLE
[RealmDB] Require Cata Warden identity schema

### DIFF
--- a/src/shared/revision_data.h.in
+++ b/src/shared/revision_data.h.in
@@ -45,9 +45,9 @@
     #define PROJECT_REVISION_NR         "2201001"
 
     #define REALMD_DB_VERSION_NR        "22"
-    #define REALMD_DB_STRUCTURE_NR      "4"
+    #define REALMD_DB_STRUCTURE_NR      "5"
     #define REALMD_DB_CONTENT_NR        "1"
-    #define REALMD_DB_UPDATE_DESCRIPT   "Warden audit"
+    #define REALMD_DB_UPDATE_DESCRIPT   "Cata Warden identity"
 
     #define CHAR_DB_VERSION_NR          "22"
     #define CHAR_DB_STRUCTURE_NR        "6"

--- a/src/tests/DatabaseVersionTest.cpp
+++ b/src/tests/DatabaseVersionTest.cpp
@@ -27,9 +27,10 @@
 TEST(CoreDatabaseVersion_requires_coordinated_warden_schemas)
 {
     CHECK_STR(GitRevision::GetRealmDBVersion(), "22");
-    CHECK_STR(GitRevision::GetRealmDBStructure(), "4");
+    CHECK_STR(GitRevision::GetRealmDBStructure(), "5");
     CHECK_STR(GitRevision::GetRealmDBContent(), "1");
-    CHECK_STR(GitRevision::GetRealmDBUpdateDescription(), "Warden audit");
+    CHECK_STR(GitRevision::GetRealmDBUpdateDescription(),
+        "Cata Warden identity");
 
     CHECK_STR(GitRevision::GetCharDBVersion(), "22");
     CHECK_STR(GitRevision::GetCharDBStructure(), "6");


### PR DESCRIPTION
## Summary

- Require shared Realm DB 22/05/001.
- Match the database description exactly: Cata Warden identity.
- Update the existing database-version regression assertion to pin the new requirement.

## Verification

- The committed revision constants match the merged Realm DB tuple and description.
- The branch differs from master only in the revision definition and its existing assertion.
- git diff --check passes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangostwo/server/276)
<!-- Reviewable:end -->
